### PR TITLE
[#73537056] Hide the number arrows in webkit

### DIFF
--- a/manchester_traffic_offences/assets-src/stylesheets/main.scss
+++ b/manchester_traffic_offences/assets-src/stylesheets/main.scss
@@ -101,3 +101,10 @@ table th.header {font-size: 1.2em;}
 .related {position: absolute; right: 1.75em; margin: 3em 0 0 0; width: 15.75em; border-top: 10px solid #d53880;}
 .related #stat {font-size:5em; font-weight:bold; margin-left: 20%;}
 .js-enabled .related-positioning {top: 8em;}
+
+// Hide widgets for number fields in webkit
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}

--- a/manchester_traffic_offences/assets/stylesheets/main.css
+++ b/manchester_traffic_offences/assets/stylesheets/main.css
@@ -1650,3 +1650,8 @@ table th.header {
 
 .js-enabled .related-positioning {
   top: 8em; }
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0; }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/73537056 asks for number inputs to be converted to text.  This makes the two fields look the same, but provides better accessibility and mobile keyboard changes.
