### PR TITLE
Hearing date field showing invalid format error when empty

### DIFF
--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -179,6 +179,9 @@ class HearingDateWidget(MultiWidget):
         except (ValueError, TypeError):
             year = None
 
+        if day == month == year == None:
+            return ""
+
         try:
             return str(datetime.date(day=day, month=month, year=year))
         except (ValueError, TypeError):


### PR DESCRIPTION
The django multiwidget we were using was returning data [None, None, None]
when all fields were empty, this was triggering the wrong validation
message. Now if all field values are empty value_from_datadict returns
an empty string.

[MAPDEV132]