### PR TITLE
Fix for redirection bug in plea entry screen

### DIFF
--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -104,7 +104,6 @@ class PleaStage(FormStage):
         return form_data
 
     def save(self, form_data, next_step=None):
-
         clean_data = super(PleaStage, self).save(form_data, next_step)
 
         none_guilty = True
@@ -112,6 +111,8 @@ class PleaStage(FormStage):
             for form in clean_data["PleaForms"]:
                 if form["guilty"] == "guilty":
                     none_guilty = False
+        else:
+            return clean_data
 
         if none_guilty:
             self.all_data["your_money"]["complete"] = True


### PR DESCRIPTION
When the plea screen was submitted without a plea chosen it was
redirecting to the case screen without error. A fix has been
applied and some tests added.

[MAPDEV139]