### PR TITLE
Remove 'optional' tag using context var

### DIFF
--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -196,12 +196,7 @@ class YourMoneyForm(BasePleaStepForm):
         except IndexError:
             data = {}
 
-        
-
-        if "you_are" in data:
-            for field in self.fields:
-                self.fields[field].required = False
-                
+        if "you_are" in data:                
             if data["you_are"] == "Employed":
                 self.fields["employed_your_job"].required = True
                 self.fields["employed_take_home_pay_period"].required = True

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -87,15 +87,15 @@ class YourMoneyForm(BasePleaStepForm):
                                 error_messages={"required": ERROR_MESSAGES["YOU_ARE_REQUIRED"]})
     # Employed
     employed_your_job = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-                                        required=True, max_length=500, label="What's your job?",
+                                        required=False, max_length=500, label="What's your job?",
                                         error_messages={"required": ERROR_MESSAGES["YOUR_JOB_REQUIRED"]})
 
     employed_take_home_pay_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                                      choices=PERIOD_CHOICES, required=True,
+                                                      choices=PERIOD_CHOICES, required=False,
                                                       label="How often do you get paid?",
                                                       error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                                       "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    employed_take_home_pay_amount = forms.CharField(label="What's your take home pay (after tax)?", required=True,
+    employed_take_home_pay_amount = forms.CharField(label="What's your take home pay (after tax)?", required=False,
                                                     widget=forms.TextInput(attrs={"maxlength": "7",
                                                                                   "data-label-template-value": "employed_take_home_pay_period",
                                                                                   "data-label-template": "What's your {0} take home pay (after tax)?",
@@ -109,18 +109,18 @@ class YourMoneyForm(BasePleaStepForm):
                                                widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                choices=YESNO_CHOICES,
                                                coerce=to_bool,
-                                               required=True)
+                                               required=False)
 
     # Self employed
     your_job = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-                               required=True, max_length=100, label="What's your job?",
+                               required=False, max_length=100, label="What's your job?",
                                error_messages={"required": ERROR_MESSAGES["YOUR_JOB_REQUIRED"]})
     self_employed_pay_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                                 choices=SE_PERIOD_CHOICES, required=True,
+                                                 choices=SE_PERIOD_CHOICES, required=False,
                                                  label="How often do you get paid?",
                                                  error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                                  "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    self_employed_pay_amount = forms.CharField(label="What's your average take home pay?", required=True,
+    self_employed_pay_amount = forms.CharField(label="What's your average take home pay?", required=False,
                                                widget=forms.TextInput(attrs={"maxlength": "7",
                                                                              "data-label-template-value": "self_employed_pay_period",
                                                                              "data-label-template": "What's your average {0} take home pay?",
@@ -128,7 +128,7 @@ class YourMoneyForm(BasePleaStepForm):
                                                                              "class": "form-control-inline"}),
                                                error_messages={"required": ERROR_MESSAGES["PAY_AMOUNT_REQUIRED"],
                                                                "incomplete": ERROR_MESSAGES["PAY_AMOUNT_REQUIRED"]})
-    self_employed_pay_other = forms.CharField(required=True, max_length=500, label="",
+    self_employed_pay_other = forms.CharField(required=False, max_length=500, label="",
                                               widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}),
                                               help_text="Tell us about how often you get paid")
 
@@ -137,23 +137,23 @@ class YourMoneyForm(BasePleaStepForm):
                                                     widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                     choices=YESNO_CHOICES,
                                                     coerce=to_bool,
-                                                    required=True)
+                                                    required=False)
 
     # On benefits
-    benefits_details = forms.CharField(required=True, max_length=500, label="Which benefits do you receive?",
+    benefits_details = forms.CharField(required=False, max_length=500, label="Which benefits do you receive?",
                                        widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}))
-    benefits_dependents = forms.ChoiceField(required=True, widget=RadioSelect(renderer=DSRadioFieldRenderer),
+    benefits_dependents = forms.ChoiceField(required=False, widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                             choices=YES_NO,
                                             label="Does this include payment for dependants?")
     benefits_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                        choices=BEN_PERIOD_CHOICES, required=True,
+                                        choices=BEN_PERIOD_CHOICES, required=False,
                                         label="How often are your benefits paid?",
                                         error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                         "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    benefits_pay_other = forms.CharField(required=True, max_length=500, label="",
+    benefits_pay_other = forms.CharField(required=False, max_length=500, label="",
                                          widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}),
                                          help_text="Tell us about how often you get paid")
-    benefits_amount = forms.CharField(label="What's your average take home pay?", required=True,
+    benefits_amount = forms.CharField(label="What's your average take home pay?", required=False,
                                       widget=forms.TextInput(attrs={"maxlength": "7",
                                                                     "data-label-template-value": "benefits_period",
                                                                     "data-label-template": "What's your average {0} take home pay?",
@@ -167,14 +167,14 @@ class YourMoneyForm(BasePleaStepForm):
                                                          widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                          choices=YESNO_CHOICES,
                                                          coerce=to_bool,
-                                                         required=True)
+                                                         required=False)
 
     # Other
-    other_details = forms.CharField(required=True, max_length=500, label="Please provide details",
+    other_details = forms.CharField(required=False, max_length=500, label="Please provide details",
                                     help_text="eg retired, student etc.",
                                     widget=forms.TextInput(attrs={"class": "form-control"}), 
                                     error_messages={"required": ERROR_MESSAGES["OTHER_INFO_REQUIRED"]})
-    other_pay_amount = forms.CharField(label="What is your monthly disposable income?", required=True,
+    other_pay_amount = forms.CharField(label="What is your monthly disposable income?", required=False,
                                        widget=forms.TextInput(attrs={"maxlength": "7", 
                                                                      "size": "10",
                                                                      "class": "form-control-inline"}),
@@ -186,7 +186,7 @@ class YourMoneyForm(BasePleaStepForm):
                                             widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                             choices=YESNO_CHOICES,
                                             coerce=to_bool,
-                                            required=True)
+                                            required=False)
 
 
     def __init__(self, *args, **kwargs):

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -87,15 +87,15 @@ class YourMoneyForm(BasePleaStepForm):
                                 error_messages={"required": ERROR_MESSAGES["YOU_ARE_REQUIRED"]})
     # Employed
     employed_your_job = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-                                        required=False, max_length=500, label="What's your job?",
+                                        required=True, max_length=500, label="What's your job?",
                                         error_messages={"required": ERROR_MESSAGES["YOUR_JOB_REQUIRED"]})
 
     employed_take_home_pay_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                                      choices=PERIOD_CHOICES, required=False,
+                                                      choices=PERIOD_CHOICES, required=True,
                                                       label="How often do you get paid?",
                                                       error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                                       "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    employed_take_home_pay_amount = forms.CharField(label="What's your take home pay (after tax)?", required=False,
+    employed_take_home_pay_amount = forms.CharField(label="What's your take home pay (after tax)?", required=True,
                                                     widget=forms.TextInput(attrs={"maxlength": "7",
                                                                                   "data-label-template-value": "employed_take_home_pay_period",
                                                                                   "data-label-template": "What's your {0} take home pay (after tax)?",
@@ -109,18 +109,18 @@ class YourMoneyForm(BasePleaStepForm):
                                                widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                choices=YESNO_CHOICES,
                                                coerce=to_bool,
-                                               required=False)
+                                               required=True)
 
     # Self employed
     your_job = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-                               required=False, max_length=100, label="What's your job?",
+                               required=True, max_length=100, label="What's your job?",
                                error_messages={"required": ERROR_MESSAGES["YOUR_JOB_REQUIRED"]})
     self_employed_pay_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                                 choices=SE_PERIOD_CHOICES, required=False,
+                                                 choices=SE_PERIOD_CHOICES, required=True,
                                                  label="How often do you get paid?",
                                                  error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                                  "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    self_employed_pay_amount = forms.CharField(label="What's your average take home pay?", required=False,
+    self_employed_pay_amount = forms.CharField(label="What's your average take home pay?", required=True,
                                                widget=forms.TextInput(attrs={"maxlength": "7",
                                                                              "data-label-template-value": "self_employed_pay_period",
                                                                              "data-label-template": "What's your average {0} take home pay?",
@@ -128,7 +128,7 @@ class YourMoneyForm(BasePleaStepForm):
                                                                              "class": "form-control-inline"}),
                                                error_messages={"required": ERROR_MESSAGES["PAY_AMOUNT_REQUIRED"],
                                                                "incomplete": ERROR_MESSAGES["PAY_AMOUNT_REQUIRED"]})
-    self_employed_pay_other = forms.CharField(required=False, max_length=500, label="",
+    self_employed_pay_other = forms.CharField(required=True, max_length=500, label="",
                                               widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}),
                                               help_text="Tell us about how often you get paid")
 
@@ -137,23 +137,23 @@ class YourMoneyForm(BasePleaStepForm):
                                                     widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                     choices=YESNO_CHOICES,
                                                     coerce=to_bool,
-                                                    required=False)
+                                                    required=True)
 
     # On benefits
-    benefits_details = forms.CharField(required=False, max_length=500, label="Which benefits do you receive?",
+    benefits_details = forms.CharField(required=True, max_length=500, label="Which benefits do you receive?",
                                        widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}))
-    benefits_dependents = forms.ChoiceField(required=False, widget=RadioSelect(renderer=DSRadioFieldRenderer),
+    benefits_dependents = forms.ChoiceField(required=True, widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                             choices=YES_NO,
                                             label="Does this include payment for dependants?")
     benefits_period = forms.ChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                        choices=BEN_PERIOD_CHOICES, required=False,
+                                        choices=BEN_PERIOD_CHOICES, required=True,
                                         label="How often are your benefits paid?",
                                         error_messages={"required": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"],
                                                         "incomplete": ERROR_MESSAGES["PAY_PERIOD_REQUIRED"]})
-    benefits_pay_other = forms.CharField(required=False, max_length=500, label="",
+    benefits_pay_other = forms.CharField(required=True, max_length=500, label="",
                                          widget=forms.Textarea(attrs={"rows": "2", "class": "form-control"}),
                                          help_text="Tell us about how often you get paid")
-    benefits_amount = forms.CharField(label="What's your average take home pay?", required=False,
+    benefits_amount = forms.CharField(label="What's your average take home pay?", required=True,
                                       widget=forms.TextInput(attrs={"maxlength": "7",
                                                                     "data-label-template-value": "benefits_period",
                                                                     "data-label-template": "What's your average {0} take home pay?",
@@ -167,14 +167,14 @@ class YourMoneyForm(BasePleaStepForm):
                                                          widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                                          choices=YESNO_CHOICES,
                                                          coerce=to_bool,
-                                                         required=False)
+                                                         required=True)
 
     # Other
-    other_details = forms.CharField(required=False, max_length=500, label="Please provide details",
+    other_details = forms.CharField(required=True, max_length=500, label="Please provide details",
                                     help_text="eg retired, student etc.",
                                     widget=forms.TextInput(attrs={"class": "form-control"}), 
                                     error_messages={"required": ERROR_MESSAGES["OTHER_INFO_REQUIRED"]})
-    other_pay_amount = forms.CharField(label="What is your monthly disposable income?", required=False,
+    other_pay_amount = forms.CharField(label="What is your monthly disposable income?", required=True,
                                        widget=forms.TextInput(attrs={"maxlength": "7", 
                                                                      "size": "10",
                                                                      "class": "form-control-inline"}),
@@ -186,7 +186,7 @@ class YourMoneyForm(BasePleaStepForm):
                                             widget=RadioSelect(renderer=DSRadioFieldRenderer),
                                             choices=YESNO_CHOICES,
                                             coerce=to_bool,
-                                            required=False)
+                                            required=True)
 
 
     def __init__(self, *args, **kwargs):
@@ -196,7 +196,12 @@ class YourMoneyForm(BasePleaStepForm):
         except IndexError:
             data = {}
 
+        
+
         if "you_are" in data:
+            for field in self.fields:
+                self.fields[field].required = False
+                
             if data["you_are"] == "Employed":
                 self.fields["employed_your_job"].required = True
                 self.fields["employed_take_home_pay_period"].required = True

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -130,6 +130,11 @@ class YourMoneyStage(FormStage):
     form_classes = [YourMoneyForm]
     dependencies = ["case", "your_details", "plea"]
 
+    def render(self, request_context):
+        self.context['hide_optional'] = True
+
+        return super(YourMoneyStage, self).render(request_context)
+
     def save(self, form_data, next_step=None):
 
         clean_data = super(YourMoneyStage, self).save(form_data, next_step)

--- a/manchester_traffic_offences/templates/widgets/money_field.html
+++ b/manchester_traffic_offences/templates/widgets/money_field.html
@@ -1,12 +1,12 @@
 <div class="form-group{% if field.errors %} with-error{% endif %}" id="section_{{ field.name }}">
-    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required %} <span class="form-hint-inline">(optional)</span>{% endif %}
+    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required and not hide_optional %} <span class="form-hint-inline">(optional)</span>{% endif %}
     	{% if field.help_text %}
     	<span class="form-hint">{{ field.help_text|safe }}</span>
     	{% endif %}
 
     	{{ field.errors }}
     </label>
-    <div class="form-field-prefixed">
+    <div class="form-field">
 		<span class="form-field-prefix">£</span>
 	    {{ field }}
     </div>

--- a/manchester_traffic_offences/templates/widgets/radio_field.html
+++ b/manchester_traffic_offences/templates/widgets/radio_field.html
@@ -1,5 +1,5 @@
 <div class="form-group-wide inline{% if field.errors %} with-error{% endif %}" id="section_{{ field.name }}">
-    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required %} <span class="form-hint-inline">(optional)</span>{% endif %}
+    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required and not hide_optional %} <span class="form-hint-inline">(optional)</span>{% endif %}
     	{% if field.help_text %}
     	<span class="form-hint">{{ field.help_text|safe }}</span>
     	{% endif %}

--- a/manchester_traffic_offences/templates/widgets/std_field.html
+++ b/manchester_traffic_offences/templates/widgets/std_field.html
@@ -1,5 +1,5 @@
 <div class="form-group{% if field.errors %} with-error{% endif %}" id="section_{{ field.name }}">
-    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required %} <span class="form-hint-inline">(optional)</span>{% endif %}
+    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required and not hide_optional %} <span class="form-hint-inline">(optional)</span>{% endif %}
     	{% if field.help_text %}
     	<span class="form-hint">{{ field.help_text|safe }}</span>
     	{% endif %}

--- a/manchester_traffic_offences/templates/widgets/wide_field.html
+++ b/manchester_traffic_offences/templates/widgets/wide_field.html
@@ -1,5 +1,5 @@
 <div class="form-group-wide{% if field.errors %} with-error{% endif %}" id="section_{{ field.name }}">
-    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required %} <span class="form-hint-inline">(optional)</span>{% endif %}
+    <label for="{{ field.id_for_label }}">{{ field.label }}{% if not field.field.required and not hide_optional %} <span class="form-hint-inline">(optional)</span>{% endif %}
     	{% if field.help_text %}
     	<span class="form-hint">{{ field.help_text|safe }}</span>
     	{% endif %}


### PR DESCRIPTION
On the 'Your money' screen, all fields are required, but this requirement
needs deactivating for validation to catch only the relevant fields. Now a
'hide_optional' context var can be set to force hide the 'Optional' tag.