### PR TITLE
MoJ Template version update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ Pillow==2.5.3
 
 lxml==3.4.0 
 # MOJ Template
-django-moj-template==0.23.0
+django-moj-template==0.23.1
 
 django_extensions==1.3.7
 django-brake==1.3.1


### PR DESCRIPTION
This allows using the js_gt_ie template block to filter the minimum
IE version that gets JS functionality. Also resolves the issue of
empty conditional tag being rendered in IE6~8.