### PR TITLE
Migrate inline statuses to an action list

### DIFF
--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -1,9 +1,24 @@
 from django.contrib import admin
 
-from apps.plea.models import UsageStats
+from apps.plea.models import UsageStats, Case, CaseAction
+
 
 class UsageStatsAdmin(admin.ModelAdmin):
     list_display = ('start_date', 'online_submissions', 'postal_requisitions', 'postal_responses')
     list_editable = ('postal_requisitions', 'postal_responses')
 
+
+class InlineCaseAction(admin.StackedInline):
+    model = CaseAction
+    extra = 0
+    readonly_fields = ('date',)
+
+
+class CaseAdmin(admin.ModelAdmin):
+    list_display = ("urn", "name", "sent", "processed")
+    inlines = [InlineCaseAction,]
+    search_fields = ["urn"]
+
+
 admin.site.register(UsageStats, UsageStatsAdmin)
+admin.site.register(Case, CaseAdmin)

--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -52,4 +52,11 @@ def send_plea_email(context_data, plea_email_to=None, send_user_email=False):
 
     email_send_court.delay(case.id, email_count.id, context_data)
 
+    case.add_action("Sent", "Email tasks created")
+    case.sent = True
+    case.save()
+
+    email_count.sent = True
+    email_count.save()
+
     return True

--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -27,6 +27,7 @@ def email_send_court(self, case_id, count_id, email_data):
     # No error trapping, let these fail hard if the objects can't be found
     case = Case.objects.get(pk=case_id)
     email_count = CourtEmailCount.objects.get(pk=count_id)
+    case.add_action("Court email started", "")
 
     email_body = "<<<makeaplea-ref: {}/{}>>>".format(case.id, email_count.id)
 
@@ -42,28 +43,30 @@ def email_send_court(self, case_id, count_id, email_data):
                         email_body,
                         route="GSI")
     except (smtplib.SMTPException, socket.error, socket.gaierror) as exc:
-        print "\nSent {0} - {1}\n".format(settings.PLEA_EMAIL_SUBJECT.format(**email_data), exc)
         logger.error("Error sending email to court: {0}".format(exc))
-
-        case.status = "network_error"
-        case.status_info = unicode(exc)
+        case.add_action("Court email network error", unicode(exc))
         email_count.get_status_from_case(case)
         email_count.save()
         case.save()
 
         raise self.retry(exc=exc)
 
-    case.status = "sent"
-    case.save()
+    case.add_action("Court email sent", "")
+
     email_count.get_status_from_case(case)
     email_count.save()
 
-    email_send_prosecutor.delay(email_data)
-    email_send_user.delay(email_data)
+    email_send_prosecutor.delay(email_data, case_id)
+    email_send_user.delay(email_data, case_id)
 
 
 @app.task(bind=True)
-def email_send_prosecutor(self, email_data):
+def email_send_prosecutor(self, email_data, case_id):
+
+    # No error trapping, let these fail hard if the objects can't be found
+    case = Case.objects.get(pk=case_id)
+    case.add_action("Prosecutor email started", "")
+
     plp_email_to = settings.PLP_EMAIL_TO
 
     plp_email = TemplateAttachmentEmail(settings.PLP_EMAIL_FROM,
@@ -79,17 +82,23 @@ def email_send_prosecutor(self, email_data):
                        route="GSI")
     except (smtplib.SMTPException, socket.error, socket.gaierror) as exc:
         logger.error("Error sending email to prosecutor: {0}".format(exc))
+        case.add_action("Prosecutor email network error", unicode(exc))
         raise self.retry(email_data, exc=exc)
+
+    case.add_action("Prosecutor email sent", "")
 
     return True
 
 
 @app.task(bind=True)
-def email_send_user(self, email_data):
+def email_send_user(self, email_data, case_id):
     """
     Dispatch an email to the user to confirm that their plea submission
     was successful.
     """
+    # No error trapping, let these fail hard if the objects can't be found
+    case = Case.objects.get(pk=case_id)
+    case.add_action("User email started", "")
 
     from .stages import get_plea_type
 
@@ -122,5 +131,9 @@ def email_send_user(self, email_data):
         email.send(fail_silently=False)
     except (smtplib.SMTPException, socket.error, socket.gaierror) as exc:
         logger.error("Error sending user confirmation email: {0}".format(exc))
+        case.add_action("Prosecutor email network error", unicode(exc))
         self.retry(email_data, exc=exc)
+
+    case.add_action("User email sent", "")
+
     return True

--- a/apps/plea/tests/test_audit.py
+++ b/apps/plea/tests/test_audit.py
@@ -56,10 +56,10 @@ class CaseCreationTests(TestCase):
 
         case = Case.objects.all()[0]
         self.assertEqual(Case.objects.all()[0].urn, self.context_data['case']['urn'].upper())
-        self.assertEqual(case.status, "sent")
+        self.assertTrue(case.sent)
 
         count_obj = CourtEmailCount.objects.all().order_by('-id')[0]
-        self.assertEqual(case.status, count_obj.status)
+        self.assertEqual(case.sent, count_obj.sent)
 
         file_glob = '{}*.gpg'.format(self.context_data['case']['urn'].replace('/', '-').upper())
 
@@ -96,11 +96,13 @@ class CaseCreationTests(TestCase):
             pass
 
         case = Case.objects.all().order_by('-id')[0]
-        self.assertEqual(case.status, "network_error")
-        self.assertEqual(case.status_info, u"Email failed to send, socket error")
+        action = case.get_actions("Court email network error")
+        self.assertTrue(len(action) > 0)
+        self.assertEqual(action[0].status_info, u"Email failed to send, socket error")
 
         count_obj = CourtEmailCount.objects.all().order_by('-id')[0]
-        self.assertEqual(case.status, count_obj.status)
+        self.assertEqual(case.sent, count_obj.sent)
+        self.assertEqual(case.processed, count_obj.processed)
 
         # confirm we have a new file:
 

--- a/apps/plea/tests/test_fields.py
+++ b/apps/plea/tests/test_fields.py
@@ -12,7 +12,7 @@ from ..models import Case
 class TestUrnValidator(TestCase):
 
     def setUp(self):
-        self.case = Case.objects.create(urn="00/AA/00000/00", status="sent")
+        self.case = Case.objects.create(urn="00/AA/00000/00", sent=True)
 
     def test_urn_does_not_match(self):
 

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -109,7 +109,7 @@ class TestMultiPleaForms(TestCase):
 
         case = Case()
         case.urn = "00/AA/0000000/00"
-        case.status = "sent"
+        case.sent = True
         case.save()
 
         form = PleaOnlineForms("case", "plea_form_step", self.session)
@@ -721,23 +721,19 @@ class TestMultiPleaForms(TestCase):
 
         case = Case()
         case.urn = urn
-        case.status = "sent"
+        case.sent = True
         case.save()
 
         self.session['case'] = dict(urn=urn)
 
-        stages = ['case', 'your_details', 'plea', 'your_money', 'review', 'complete']
+        form = PleaOnlineForms("case", "plea_form_step", self.session)
+        form.load(self.request_context)
+        form.save({}, self.request_context)
 
-        for stage in stages:
+        response = form.render()
 
-            form = PleaOnlineForms(stage, "plea_form_step", self.session)
-            form.load(self.request_context)
-            form.save({}, self.request_context)
-
-            response = form.render()
-
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response.url, reverse('urn_already_used'))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('urn_already_used'))
 
     def test_urn_not_success_is_not_blocked(self):
 

--- a/apps/receipt/process.py
+++ b/apps/receipt/process.py
@@ -200,11 +200,9 @@ def _process_receipts(log_entry):
                 continue
 
             if status == "Passed":
-                if case_obj.status == "receipt_success":
+                if case_obj.has_action("receipt_success"):
                     status_text.append("{} already processed. Skipping.").format(urn)
                     continue
-
-                case_obj.status = "receipt_success"
 
                 log_entry.total_success += 1
 
@@ -213,12 +211,11 @@ def _process_receipts(log_entry):
 
                     old_urn, case_obj.urn = case_obj.urn, urn
 
-                    case_obj.status_info = \
-                        (case_obj.status_info or "") +\
-                        "\nURN CHANGED! Old Urn: {}".format(old_urn)
+                    case_obj.add_action("receipt_success", "\URN CHANGED! Old Urn: {}".format(old_urn))
 
                     status_text.append('Passed [URN CHANGED! old urn: {}] {}'.format(urn, old_urn))
                 else:
+                    case_obj.add_action("receipt_success", "")
                     status_text.append('Passed: {}'.format(urn))
 
                 case_obj.save()
@@ -231,7 +228,7 @@ def _process_receipts(log_entry):
                 #
 
             else:
-                case_obj.status = "receipt_failure"
+                case_obj.add_action("receipt_failure", "")
 
                 status_text.append('Failed: {}'.format(urn))
 


### PR DESCRIPTION
The inline status fields on the case table wasn't expressive enough to
capture all of the actions of sending emails via celery tasks and
processing receipts. We've moved to a more immediate set of boolean
flags on the case and emailcount objects and also a list of actions
on the case object.

[MAPDEV167]