### PR TITLE
Templated Element Module - Fix mutliple delegates default text

### DIFF
--- a/manchester_traffic_offences/assets-src/javascripts/modules/moj.TemplatedElement.js
+++ b/manchester_traffic_offences/assets-src/javascripts/modules/moj.TemplatedElement.js
@@ -44,7 +44,7 @@
         $el = $($el.data('templateDelegate'));
       }
 
-      this.originalText = $el.text();
+      this.originalText = $el.eq(0).text();
 
       this.cacheElements($el);
 

--- a/manchester_traffic_offences/assets-src/tests/moj.TemplatedElement.spec.js
+++ b/manchester_traffic_offences/assets-src/tests/moj.TemplatedElement.spec.js
@@ -109,4 +109,20 @@ describe("moj.TemplatedElement", function() {
     $('#radio_1').trigger('click');
     expect($('#delegate').text()).toBe('Templated content, value = one');
   });
+
+  it('should use the default text from the first element only', function() {
+    $fixture = $(
+      '<div class="test_control">'
+      + '<input id="radio_1" name="testField" type="radio" value="one"/>'
+      + '<input id="radio_2" name="testField" type="radio" value="two"/>'
+      + '<div class="js-TemplatedElement" data-template-trigger="testField" data-template="Templated content, value = {value}" data-template-defaults-for="two" data-template-delegate=".delegate">Default content</div>'
+      + '<div class="delegate">Another element</div>'
+      + '<div class="delegate">Another element</div>'
+      + '</div>'
+    );
+    $fixture.appendTo('body');
+    subject = new moj.Modules._TemplatedElement($fixture.find('.js-TemplatedElement'));
+
+    expect(subject.originalText).toBe('Another element');
+  });
 });

--- a/manchester_traffic_offences/assets/javascripts/application.js
+++ b/manchester_traffic_offences/assets/javascripts/application.js
@@ -471,7 +471,7 @@ if(typeof String.prototype.trim !== 'function') {
         $el = $($el.data('templateDelegate'));
       }
 
-      this.originalText = $el.text();
+      this.originalText = $el.eq(0).text();
 
       this.cacheElements($el);
 


### PR DESCRIPTION
When mutliple elements are set as delegates, the default text was
a concatenation of the text from all elements. From now on only the first
one is used.

[hotfix]