### PR TITLE
Fix missing mixed pleas message on Success screen

### DIFF
--- a/manchester_traffic_offences/templates/plea/complete.html
+++ b/manchester_traffic_offences/templates/plea/complete.html
@@ -14,12 +14,14 @@ Your guilty plea has been sent to the court
     {% plural %}
 Your guilty pleas have been sent to the court
     {% endblocktrans %}
-{% else %}
+{% elif plea_type == "not_guilty" %}
     {% blocktrans count charges=case.number_of_charges %}
 Your not guilty plea has been sent to the court
     {% plural %}
 Your not guilty pleas have been sent to the court
     {% endblocktrans %}
+{% elif plea_type == "mixed" %}
+    {% trans "Your pleas have been sent to the court" %}
 {% endif %}</h1>
 </header>
 


### PR DESCRIPTION
Message displayed was only tailored for fully 'guilty' or 'not guilty'
pleas, ignoring mixed cases. A single message has been added (mixed
pleas are always plural!)