### PR TITLE
Hotfix for stage not set issue

### DIFF
--- a/apps/govuk_utils/forms.py
+++ b/apps/govuk_utils/forms.py
@@ -163,6 +163,8 @@ class MultiStageForm(object):
         self.all_data[self.current_stage.name].update(self.current_stage.save(form_data, next_step=next_url))
         self.save_to_storage()
 
+        return True
+
     def process_messages(self, request):
         if self.current_stage is None:
             raise Exception("Current stage is not set")

--- a/apps/plea/tests/test_issues.py
+++ b/apps/plea/tests/test_issues.py
@@ -1,0 +1,40 @@
+import unittest
+
+from ..views import PleaOnlineForms
+from ..models import Case
+
+from test_plea_form import TestMultiPleaFormBase
+
+
+class TestPleaFormIssues(TestMultiPleaFormBase):
+    def setUp(self):
+        self.session = {}
+        self.request_context = {}
+
+        self.plea_stage_pre_data_1_charge = {"case": {"date_of_hearing": "2015-01-01",
+                                                      "urn_0": "06",
+                                                      "urn_1": "AA",
+                                                      "urn_2": "0000000",
+                                                      "urn_3": "00",
+                                                      "number_of_charges": 1,
+                                                      "company_plea": False},
+                                             "your_details": {"name": "Charlie Brown",
+                                                              "contact_number": "012345678",
+                                                              "email": "charliebrown@example.org"}}
+
+
+    def test_used_urn_in_session(self):
+        case = Case.objects.create(urn="06/AA/0000000/00", name="Ian George",
+                                   status="sent")
+        case.save()
+
+        self.session = {"case": {"complete": True,
+                                 "date_of_hearing": "2015-01-01",
+                                 "urn": "06/AA/0000000/00",
+                                 "number_of_charges": 1,
+                                 "company_plea": False}}
+
+        form = PleaOnlineForms("case", "plea_form_step", self.session)
+        form.save(self.plea_stage_pre_data_1_charge, self.request_context)
+
+        self.assertTrue(form._urn_invalid)

--- a/apps/plea/tests/test_issues.py
+++ b/apps/plea/tests/test_issues.py
@@ -1,5 +1,7 @@
 import unittest
 
+from django.http.response import HttpResponseRedirect
+
 from ..views import PleaOnlineForms
 from ..models import Case
 
@@ -37,4 +39,6 @@ class TestPleaFormIssues(TestMultiPleaFormBase):
         form = PleaOnlineForms("case", "plea_form_step", self.session)
         form.save(self.plea_stage_pre_data_1_charge, self.request_context)
 
-        self.assertTrue(form._urn_invalid)
+        result = form.render()
+        self.assertIsInstance(result, HttpResponseRedirect)
+

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -38,7 +38,6 @@ class PleaOnlineForms(MultiStageForm):
         """
         Check that the URN has not already been used.
         """
-
         try:
             saved_urn = self.all_data['case']['urn']
         except KeyError:
@@ -49,7 +48,7 @@ class PleaOnlineForms(MultiStageForm):
 
             return
 
-        super(PleaOnlineForms, self).save(*args, **kwargs)
+        return super(PleaOnlineForms, self).save(*args, **kwargs)
 
     @never_cache
     def render(self):
@@ -87,7 +86,8 @@ class PleaOnlineViews(TemplateView):
 
         form = PleaOnlineForms(stage, "plea_form_step", request.session)
         form.save(request.POST, RequestContext(request), nxt)
-        form.process_messages(request)
+        if not form._urn_invalid:
+            form.process_messages(request)
         return form.render()
 
 

--- a/manchester_traffic_offences/templates/plea/urn_used.html
+++ b/manchester_traffic_offences/templates/plea/urn_used.html
@@ -2,59 +2,38 @@
 
 {% load i18n %}
 
-{% block page_title %}{{ block.super }} URN already used{% endblock %}
-{% block body_classes %}{{ block.super }} urn_invalid{% endblock %}
+{% block page_title %}{% trans "URN already used" %} - {{ block.super }}{% endblock %}
+
 {% load staticfiles %}
+
 {% block page_content %}
 
-    <div class="full-width group">
-        <div class="main">
+    <div class="error-summary">
 
-            <section class="flash error-summary no_margin">
+        <h2>{% trans "This URN has already been used to make a plea online" %}</h2>
 
-                <h2 id="error-heading">{% trans "This URN has already been used to make a plea online" %}</h2>
+        <p>{% trans "The unique reference number you entered is no longer valid. Please check and try again." %}</p>
 
-                <p>{% trans "The unique reference number you entered is no longer valid. Please check and try again." %}</p>
+        <p>{% trans "To make changes to a plea you’ve already made online, email or write to the court before your hearing with:" %}</p>
 
-                <p>{% trans "To make changes to a plea you’ve already made online, email or write to the court before your hearing with:" %}</p>
+        <ul class="list-bullet">
+            <li>{% trans "details of the changes you want to make" %}</li>
+            <li>{% trans "your unique reference number" %}</li>
+        </ul>
 
-                <ul class="with-bullets">
-                    <li>{% trans "details of the changes you want to make" %}</li>
-                    <li>{% trans "your unique reference number" %}</li>
-                </ul>
+        <p><a href="/court-finder/">Find court contact details</a></p>
 
-
-                <ul>
-                    <li id="case_contact_link"><a href="/contact">{% trans "View court contact details" %}</a></li>
-                    <li id="case_contact_details" class="js-hidden">
-
-
-                    <h2>{% trans "Send letters to:" %}</h2>
-                    <p>The Operations Manager<br>
-                    Manchester & Salford<br>
-                    Magistrates Court<br>
-                    Crown Square<br>
-                    Manchester<br>
-                    M60 1PR</p>
-
-                    <p><h2>{% trans "Send email to:" %}</h2>
-                    <a href="mailto:roadtrafficpcr@hmcts.gsi.gov.uk">roadtrafficpcr@hmcts.gsi.gov.uk</a></p>
-
-                    </li>
-                </ul>
-
-            </section>
-
-
-            <h2 id="your-details">{% trans "Create a new plea" %}</h2>
-
-            <p>{% trans "Select the button below to start a new plea" %}</p>
-
-            <form method="post">
-                {% csrf_token %}
-                <button class="button button-get-started" href="/plea/" role="button">{% trans "Start now" %}</button>
-            </form>
-        </div>
     </div>
+
+
+    <h2>{% trans "Create a new plea" %}</h2>
+
+    <p>{% trans "Select the button below to start a new plea" %}</p>
+
+    <form method="post">
+        {% csrf_token %}
+        <button class="button button-get-started" href="/plea/" role="button">{% trans "Start now" %}</button>
+    </form>
+
 
 {% endblock page_content %}


### PR DESCRIPTION
Users were somehow (still not identified how) getting back into the
forms with a used URN still in session. The path for this wasn't
quite dealing with the situation, this removes the code causing the
error from the execution path, allowing the "URN already used" page
to be displayed.

[MAPDEV269]