### PR TITLE
Complete screen updates

### DIFF
--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -136,6 +136,7 @@ def email_send_user(self, email_data, case_id):
     data = {
         'email': email,
         'urn': email_data['case']['urn'],
+        'plea_made_by': email_data['case']['plea_made_by'],
         'number_of_charges': email_data['case']['number_of_charges'],
         'plea_type': get_plea_type(email_data),
         'name': name,

--- a/apps/plea/tests/test_email_generation.py
+++ b/apps/plea/tests/test_email_generation.py
@@ -104,6 +104,7 @@ class EmailGenerationTests(TestCase):
 
         self.assertEqual(len(mail.outbox), 3)
         self.assertIn(context_data['case']['urn'].upper(), mail.outbox[-1].body)
+        self.assertIn(context_data['case']['urn'].upper(), mail.outbox[-1].alternatives[0][0])
         self.assertIn(context_data['your_details']['email'], mail.outbox[-1].to)
 
     def test_user_confirmation_for_company_uses_correct_email_address(self):
@@ -132,6 +133,7 @@ class EmailGenerationTests(TestCase):
 
         self.assertEqual(len(mail.outbox), 3)
         self.assertIn(context_data['case']['urn'].upper(), mail.outbox[-1].body)
+        self.assertIn(context_data['case']['urn'].upper(), mail.outbox[-1].alternatives[0][0])
         self.assertIn(context_data['company_details']['email'], mail.outbox[-1].to)
 
     def test_email_addresses_from_court_model(self):

--- a/manchester_traffic_offences/templates/plea/complete.html
+++ b/manchester_traffic_offences/templates/plea/complete.html
@@ -3,58 +3,31 @@
 
 {% load testing %}
 
-{% block page_title %}{% blocktrans count charges=case.number_of_charges %}Your plea has been sent{% plural %}Your pleas have been sent{% endblocktrans %} - {{ block.super }}{% endblock %}
+{% block page_title %}{% blocktrans count charges=case.number_of_charges %}Your plea has been submitted{% plural %}Your pleas have been submitted{% endblocktrans %} - {{ block.super }}{% endblock %}
 
 {% block page_content %}
 
 <header class="success-header">
-    <h1 class="ticked">{% if plea_type == "guilty" %}
-    {% blocktrans count charges=case.number_of_charges %}Your guilty plea has been sent to the court{% plural %}Your guilty pleas have been sent to the court{% endblocktrans %}
-{% elif plea_type == "not_guilty" %}
-    {% blocktrans count charges=case.number_of_charges %}Your not guilty plea has been sent to the court{% plural %}Your not guilty pleas have been sent to the court{% endblocktrans %}
-{% elif plea_type == "mixed" %}
-    {% trans "Your pleas have been sent to the court" %}
-{% endif %}</h1>
+    <h1 class="ticked">
+    {% if case.plea_made_by == "Defendant" %}
+        {% blocktrans count charges=case.number_of_charges %}Your plea has been sent to the court{% plural %}Your pleas have been sent to the court{% endblocktrans %}
+    {% elif case.plea_made_by == "Company representative" %}
+        {% blocktrans count charges=case.number_of_charges %}Company plea has been submitted{% plural %}Company pleas have been submitted{% endblocktrans %}
+    {% endif %}
+    </h1>
 </header>
 
 
 <h2 class="heading-medium">{% trans "What happens next?" %}</h2>
 
 <div class="panel-indent what-next">
-    {% if plea_type == "guilty" %}
-        {% add_test_tag "<<GUILTY>>" %}
-        <ol>
-            <li>{% blocktrans %}There's <strong>no need</strong> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-            <li>{% blocktrans count charges=case.number_of_charges %}We'll send you a letter with the court's decision <strong>within three working days after your hearing.</strong>{% plural %}We'll send you a letter with the court's decisions <strong>within three working days after your hearing.</strong>{% endblocktrans %}</li>
-            <li>{% blocktrans with urn=case.urn|upper email=court.court_email  %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
-            <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this confirmation of plea for your records.{% endblocktrans %}</li>
-            <li>{% blocktrans %}If you requested email updates you'll be sent a copy of this confirmation of plea.{% endblocktrans %}</li>
-        </ol>
+    
+    {% if case.plea_made_by == "Defendant" %}
+        {% include "plea/complete/screen/whats_next_defendant.html" %}
+    {% elif case.plea_made_by == "Company representative" %}
+        {% include "plea/complete/screen/whats_next_company.html" %}
     {% endif %}
-
-    {% if plea_type == "not_guilty" %}
-        {% add_test_tag "<<NOTGUILTY>>" %}
-        <ol>
-            <li>{% blocktrans %}There's <strong>no need</strong> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-            <li>{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
-            <li>{% blocktrans count charges=case.number_of_charges %}We'll send you a letter with the court's decision <strong>within three working days after your hearing.</strong>{% plural %}We'll send you a letter with the court's decisions <strong>within three working days after your hearing.</strong>{% endblocktrans %}</li>
-            <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
-            <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this confirmation of plea for your records.{% endblocktrans %}</li>
-            <li>{% blocktrans %}If you requested email updates you'll be sent a copy of this confirmation of plea.{% endblocktrans %}</li>
-        </ol>
-    {% endif %}
-
-    {% if plea_type == "mixed" %}
-        {% add_test_tag "<<MIXED>>" %}
-        <ol>
-            <li>{% blocktrans %}There's <strong>no need</strong> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-            <li>{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
-            <li>{% blocktrans %}We'll send you a letter with the court's decisions <strong>within three working days after your hearing.</strong>{% endblocktrans %}</li>
-            <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
-            <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this confirmation of plea for your records.{% endblocktrans %}</li>
-            <li>{% blocktrans %}If you requested email updates you'll be sent a copy of this confirmation of plea.{% endblocktrans %}</li>
-        </ol>
-    {% endif %}
+    
 </div>
 
 <h2 class="heading-medium">{% trans "Need to change a plea?" %}</h2>

--- a/manchester_traffic_offences/templates/plea/complete/email_html/whats_next_company.html
+++ b/manchester_traffic_offences/templates/plea/complete/email_html/whats_next_company.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+    {% add_test_tag "<<GUILTY>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3  working days after your hearing date</strong>.</strong>{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email  %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+    {% add_test_tag "<<NOTGUILTY>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3 working days after your hearing date</strong>.{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3  working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}
+
+{% if plea_type == "mixed" %}
+    {% add_test_tag "<<MIXED>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/complete/email_html/whats_next_defendant.html
+++ b/manchester_traffic_offences/templates/plea/complete/email_html/whats_next_defendant.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+    {% add_test_tag "<<GUILTY>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">    
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3  working days after your hearing date</strong>.</strong>{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email  %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+    {% add_test_tag "<<NOTGUILTY>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>        
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3 working days after your hearing date</strong>.{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3  working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}
+
+{% if plea_type == "mixed" %}
+    {% add_test_tag "<<MIXED>>" %}
+<ol style="margin-left: 0px;padding-left:25px;">
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper email=court_email %}Quote your URN <strong>{{ urn }}</strong> if you contact the court about your case.{% endblocktrans %}</li>
+    <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}</li>
+</ol>
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/complete/email_txt/whats_next_company.txt
+++ b/manchester_traffic_offences/templates/plea/complete/email_txt/whats_next_company.txt
@@ -1,0 +1,33 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+{% add_test_tag "<<GUILTY>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}
+3. {% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision within 3  working days after your hearing date.{% plural %}We’ll send you a letter with the court’s decisions within 3 working days after your hearing date.{% endblocktrans %}
+4. {% blocktrans %}Do not send your driving licence to the court.{% endblocktrans %}
+5. {% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}
+6. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+7. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+{% add_test_tag "<<NOTGUILTY>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}
+3. {% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision within 3 working days after your hearing date.{% plural %}We’ll send you a letter with the court’s decisions within 3  working days after your hearing date.{% endblocktrans %}
+4. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+5. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}
+
+{% if plea_type == "mixed" %}
+{% add_test_tag "<<MIXED>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}
+3. {% blocktrans %}We’ll send you a letter with the court’s decisions within 3 working days after your hearing date.{% endblocktrans %}
+4. {% blocktrans %}Do not send your driving licence to the court.{% endblocktrans %}
+5. {% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}
+6. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+7. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/complete/email_txt/whats_next_defendant.txt
+++ b/manchester_traffic_offences/templates/plea/complete/email_txt/whats_next_defendant.txt
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+{% add_test_tag "<<GUILTY>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision within 3  working days after your hearing date.{% plural %}We’ll send you a letter with the court’s decisions within 3 working days after your hearing date.{% endblocktrans %}
+3. {% blocktrans %}Do not send your driving licence to the court.{% endblocktrans %}
+4. {% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}
+5. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+6. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+{% add_test_tag "<<NOTGUILTY>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}        
+3. {% blocktrans count charges=number_of_charges %}We’ll send you a letter with the court’s decision within 3 working days after your hearing date.{% plural %}We’ll send you a letter with the court’s decisions within 3  working days after your hearing date.{% endblocktrans %}
+4. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+5. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}
+
+{% if plea_type == "mixed" %}
+{% add_test_tag "<<MIXED>>" %}
+1. {% blocktrans %}There’s no need to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}
+2. {% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}
+3. {% blocktrans %}We’ll send you a letter with the court’s decisions within 3 working days after your hearing date.{% endblocktrans %}
+4. {% blocktrans %}Do not send your driving licence to the court.{% endblocktrans %}
+5. {% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}
+6. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
+7. {% blocktrans %}Print a copy of this plea confirmation for your records.{% endblocktrans %}
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/complete/screen/whats_next_company.html
+++ b/manchester_traffic_offences/templates/plea/complete/screen/whats_next_company.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+    {% add_test_tag "<<GUILTY>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+        <li>{% blocktrans count charges=case.number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3  working days after your hearing date</strong>.</strong>{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email  %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+    {% add_test_tag "<<NOTGUILTY>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+        <li>{% blocktrans count charges=case.number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3 working days after your hearing date</strong>.{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3  working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}
+
+{% if plea_type == "mixed" %}
+    {% add_test_tag "<<MIXED>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The court will tell you if a company representative needs to attend a trial, and what evidence might be needed by the court.{% endblocktrans %}</li>
+        <li>{% blocktrans %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/complete/screen/whats_next_defendant.html
+++ b/manchester_traffic_offences/templates/plea/complete/screen/whats_next_defendant.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+{% load testing %}
+
+{% if plea_type == "guilty" %}
+    {% add_test_tag "<<GUILTY>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans count charges=case.number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3  working days after your hearing date</strong>.</strong>{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email  %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}
+
+{% if plea_type == "not_guilty" %}
+    {% add_test_tag "<<NOTGUILTY>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>        
+        <li>{% blocktrans count charges=case.number_of_charges %}We’ll send you a letter with the court’s decision <strong>within 3 working days after your hearing date</strong>.{% plural %}We’ll send you a letter with the court’s decisions <strong>within 3  working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}
+
+{% if plea_type == "mixed" %}
+    {% add_test_tag "<<MIXED>>" %}
+    <ol>
+        <li>{% blocktrans %}There’s <strong>no need</strong> to come to court on the hearing date shown in the Postal Requisition.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}We’ll send you a letter with the court’s decisions <strong>within 3 working days after your hearing date</strong>.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<strong>Do not</strong> send your driving licence to the court.{% endblocktrans %}</li>
+        <li>{% blocktrans %}The DVLA will contact you if they need you to send in your driving licence.{% endblocktrans %}</li>
+        <li>{% blocktrans with urn=case.urn|upper email=court.court_email %}Quote your URN <strong>{{ urn }}</strong> if you <a href="mailto:{{ email }}">contact</a> the court about your case.{% endblocktrans %}</li>
+        <li>{% blocktrans %}<a href="javascript:window.print();">Print a copy</a> of this plea confirmation for your records.{% endblocktrans %}</li>
+    </ol>
+{% endif %}

--- a/manchester_traffic_offences/templates/plea/plea_email_confirmation.html
+++ b/manchester_traffic_offences/templates/plea/plea_email_confirmation.html
@@ -211,52 +211,45 @@
                         <table width="100%" cellpadding="30">
                             <tr>
                                 <td style="font-family:Arial, Helvetica; line-height: 21px;">
+                                
+                                {% if plea_made_by == "Defendant" %}
+                                    
                                     <h1 style="margin-bottom: 30px; margin-top:0px;">{% blocktrans count charges=number_of_charges %}Your online plea has been submitted{% plural %}Your online pleas have been submitted{% endblocktrans %}</h1>
 
                                     <p style="font-size: 18px;">
-{% if plea_type == "guilty" %}
-    {% blocktrans count charges=number_of_charges %}Your guilty plea has been sent to the court{% plural %}Your guilty pleas have been sent to the court{% endblocktrans %}
-{% else %}
-    {% blocktrans count charges=number_of_charges %}Your not guilty plea has been sent to the court{% plural %}Your not guilty pleas have been sent to the court{% endblocktrans %}
-{% endif %}
+                                    {% if plea_type == "guilty" %}
+                                        {% blocktrans count charges=number_of_charges %}Your guilty plea has been sent to the court.{% plural %}Your guilty pleas have been sent to the court.{% endblocktrans %}
+                                    {% elif plea_type == "not_guilty" %}
+                                        {% blocktrans count charges=number_of_charges %}Your not guilty plea has been sent to the court.{% plural %}Your not guilty pleas have been sent to the court.{% endblocktrans %}
+                                    {% elif plea_type == "mixed" %}
+                                        {% blocktrans count charges=number_of_charges %}Your plea has been sent to the court.{% plural %}Your pleas have been sent to the court.{% endblocktrans %}
+                                    {% endif %}
                                     </p>
+
+                                {% elif plea_made_by == "Company representative" %}
+
+                                    <h1 style="margin-bottom: 30px; margin-top:0px;">{% blocktrans count charges=number_of_charges %}Online plea submitted{% plural %}Online pleas submitted{% endblocktrans %}</h1>
+
+                                    <p style="font-size: 18px;">
+                                    {% if plea_type == "guilty" %}
+                                        {% blocktrans count charges=number_of_charges %}The guilty plea you made on behalf of your company has been sent to the court.{% plural %}The guilty pleas you made on behalf of your company have been sent to the court.{% endblocktrans %}
+                                    {% elif plea_type == "not_guilty" %}
+                                        {% blocktrans count charges=number_of_charges %}The not guilty plea you made on behalf of your company has been sent to the court.{% plural %}The not guilty pleas you made on behalf of your company have been sent to the court.{% endblocktrans %}
+                                    {% elif plea_type == "mixed" %}
+                                        {% blocktrans count charges=number_of_charges %}The plea you made on behalf of your company has been sent to the court.{% plural %}The pleas you made on behalf of your company have been sent to the court.{% endblocktrans %}
+                                    {% endif %}
+                                    </p>
+
+                                {% endif %}
+
+                                    
 
                                     <h2 style="font-size: 25px; margin-top: 50px;">{% trans "What happens next?" %}</h2>
 
-                                    {% if plea_type == "guilty" %}
-                                        {% add_test_tag "<<GUILTY>>" %}
-                                    <ol style="margin-left: 0px;padding-left:25px;">
-
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There's <b>no need</b> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We'll send you a letter with the court's decision <b>within three working days after your hearing.</b>{% plural %}We'll send you a letter with the court's decisions <b>within three working days after your hearing.</b>{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn %}Quote your URN <b>{{ urn }}</b> if you contact the court about your case.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% trans "Print a copy of this confirmation of plea for your records." %}</li>
-                                    </ol>
-                                    {% endif %}
-
-                                    {% if plea_type == "not_guilty" %}
-                                        {% add_test_tag "<<NOTGUILTY>>" %}
-                                    <ol style="margin-left: 0px;padding-left:25px;">
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There's <b>no need</b> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We'll send you a letter with the court's decision <b>within three working days after your hearing.</b>{% plural %}We'll send you a letter with the court's decisions <b>within three working days after your hearing.</b>{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper %}Quote your URN <b>{{ urn }}</b> if you contact the court about your case.{% endblocktrans %}</li>
-                                        <li style="font-size: 18px;">{% blocktrans %}Print a copy of this confirmation of plea for your records.{% endblocktrans %}</li>
-                                    </ol>
-
-                                    {% endif %}
-
-                                    {% if plea_type == "mixed" %}
-                                        {% add_test_tag "<<MIXED>>" %}
-                                    <ol>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}There's <b>no need</b> to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans %}The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans count charges=number_of_charges %}We'll send you a letter with the court's decision <b>within three working days after your hearing.</b>{% plural %}We'll send you a letter with the court's decisions <b>within three working days after your hearing.</b>{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% blocktrans with urn=urn|upper %}Quote your URN  {{ urn }} if you contact the court about your case.{% endblocktrans %}</li>
-                                        <li style="margin-bottom: 20px; font-size: 18px;">{% trans "Print a copy of this confirmation of plea for your records." %}</li>
-
-                                    </ol>
-
+                                    {% if plea_made_by == "Defendant" %}
+                                        {% include "plea/complete/email_html/whats_next_defendant.html" %}
+                                    {% elif plea_made_by == "Company representative" %}
+                                        {% include "plea/complete/email_html/whats_next_company.html" %}
                                     {% endif %}
 
                                     <h2 style="font-size: 25px; margin-top: 50px;">{% trans "Need to change a plea?" %}</h2>

--- a/manchester_traffic_offences/templates/plea/plea_email_confirmation.txt
+++ b/manchester_traffic_offences/templates/plea/plea_email_confirmation.txt
@@ -12,36 +12,10 @@
 
 {% trans "What happens next?" %}
 
-{% if plea_type == "guilty" %}
-    {% add_test_tag "<<GUILTY>>" %}
-
-1. {% trans "There's no need to come to court on the hearing date shown in the pack we sent you." %}
-2. {% trans "We'll send you a letter with the court's decision{{ case.number_of_charges|pluralize}} within three working days after your hearing." %}
-3. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
-4. {% trans "Print a copy of this confirmation of plea for your records." %}
-
-{% endif %}
-
-{% if plea_type == "not_guilty" %}
-    {% add_test_tag "<<NOTGUILTY>>" %}
-
-1. {% blocktrans %}There's no need to come to court on the hearing date shown in the pack we sent you.{% endblocktrans %}
-2. {% blocktrans %}The court will tell you if you need to attend for your trial, and what evidence you may need to send to the court in support of your case.{% endblocktrans %}
-3. {% blocktrans count charges=number_of_charges %}We'll send you a letter with the court's decision within three working days after your hearing.{% plural %}We'll send you a letter with the court's decisions within three working days after your hearing.{% endblocktrans %}
-4. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
-5. {% trans "Print a copy of this confirmation of plea for your records." %}
-
-{% endif %}
-
-{% if plea_type == "mixed" %}
-    {% add_test_tag "<<MIXED>>" %}
-
-1. {% trans "There's no need to come to court on the hearing date shown in the pack we sent you." %}
-2. {% trans "The court will tell you if you need to attend a trial, and what evidence you may need to send to the court in support of your case." %}
-3. {% trans "We'll send you a letter with the court's decisions within three working days after your hearing." %}
-4. {% blocktrans with urn=urn|upper %}Quote your URN {{ urn }} if you contact the court about your case.{% endblocktrans %}
-5. {% trans "Print a copy of this confirmation of plea for your records." %}
-
+{% if plea_made_by == "Defendant" %}
+    {% include "plea/complete/email_txt/whats_next_defendant.txt" %}
+{% elif plea_made_by == "Company representative" %}
+    {% include "plea/complete/email_txt/whats_next_company.txt" %}
 {% endif %}
 
 {% trans "Need to change a plea?" %}


### PR DESCRIPTION
'Complete' screen and confirmation email updates

Includes revised wording in the heading and "what's next" list, across screen, HTML email and text-only email versions. "What's next" lists have been abstracted for code clarity.

Email tests also updated: these were only testing the text-only version; they now check the HTML version.
