### PR TITLE
Mapdev302 company address pattern

### DIFF
--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -30,6 +30,8 @@ ERROR_MESSAGES = {
     "LAST_NAME_REQUIRED": _("Enter your last name"),
     "CORRECT_ADDRESS_REQUIRED": _("Tell us if your address on the Postal Requisition is correct"),
     "UPDATED_ADDRESS_REQUIRED": _("Tell us your address"),
+    "COMPANY_CORRECT_ADDRESS_REQUIRED": _("Tell us if the company's address on the Postal Requisition is correct"),
+    "COMPANY_UPDATED_ADDRESS_REQUIRED": _("Tell us your address"),
     "EMAIL_ADDRESS_REQUIRED": _("You must provide an email address"),
     "EMAIL_ADDRESS_INVALID": _("Email address isn't a valid format"),
     "CONTACT_NUMBER_REQUIRED": _("You must provide a contact number"),

--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -31,7 +31,7 @@ ERROR_MESSAGES = {
     "CORRECT_ADDRESS_REQUIRED": _("Tell us if your address on the Postal Requisition is correct"),
     "UPDATED_ADDRESS_REQUIRED": _("Tell us your address"),
     "COMPANY_CORRECT_ADDRESS_REQUIRED": _("Tell us if the company's address on the Postal Requisition is correct"),
-    "COMPANY_UPDATED_ADDRESS_REQUIRED": _("Tell us your address"),
+    "COMPANY_UPDATED_ADDRESS_REQUIRED": _("Tell us the company's address"),
     "EMAIL_ADDRESS_REQUIRED": _("You must provide an email address"),
     "EMAIL_ADDRESS_INVALID": _("Email address isn't a valid format"),
     "CONTACT_NUMBER_REQUIRED": _("You must provide a contact number"),

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -146,11 +146,18 @@ class CompanyDetailsForm(BasePleaStepForm):
                                    help_text=_("As written on page 1 of the Postal Requistion we sent you."),
                                    error_messages={"required": ERROR_MESSAGES["COMPANY_NAME_REQUIRED"]})
 
-    company_address = forms.CharField(label=_("Company address"),
-                                      widget=Textarea(attrs={"class": "form-control", "rows": "4"}),
-                                      help_text=_("This is the address we will use for all future correspondence about this case."),
-                                      required=True,
-                                      error_messages={"required": ERROR_MESSAGES["COMPANY_ADDRESS_REQUIRED"]})
+    correct_address = forms.TypedChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
+                                             coerce=to_bool,
+                                             choices=YESNO_CHOICES,
+                                             required=True,
+                                             label=_("Is the company's address on the requisition pack correct?"),
+                                             error_messages={"required": ERROR_MESSAGES["COMPANY_CORRECT_ADDRESS_REQUIRED"]})
+
+    updated_address = forms.CharField(widget=forms.Textarea(attrs={"rows": "4", "class": "form-control"}),
+                                      label="",
+                                      required=False,
+                                      help_text=_("If the company address is different from the one shown on page 1 of the requisition pack, tell us here:"),
+                                      error_messages={"required": ERROR_MESSAGES["COMPANY_UPDATED_ADDRESS_REQUIRED"]})
 
     first_name = forms.CharField(label=_("Your first name"),
                                  widget=forms.TextInput(attrs={"class": "form-control"}),
@@ -183,6 +190,17 @@ class CompanyDetailsForm(BasePleaStepForm):
                              label=_("Email"),
                              error_messages={"required": ERROR_MESSAGES["COMPANY_EMAIL_ADDRESS_REQUIRED"],
                                              "invalid": ERROR_MESSAGES["EMAIL_ADDRESS_INVALID"]})
+
+    def __init__(self, *args, **kwargs):
+        super(CompanyDetailsForm, self).__init__(*args, **kwargs)
+        try:
+            data = args[0]
+        except IndexError:
+            data = {}
+
+        if "correct_address" in data:
+            if data["correct_address"] == "False":
+                self.fields["updated_address"].required = True
 
 
 class YourMoneyForm(BasePleaStepForm):

--- a/apps/plea/tests/test_email_generation.py
+++ b/apps/plea/tests/test_email_generation.py
@@ -119,7 +119,7 @@ class EmailGenerationTests(TestCase):
                         },
                         "company_details": {
                             "company_name": "some company plc",
-                            "company_address": "some place plc",
+                            "updated_address": "some place plc",
                             "first_name": "John",
                             "last_name": "Smith",
                             "position_in_company": "a director",

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -598,7 +598,7 @@ class TestCompanyFinancesEmailLogic(TestCase):
             },
             "company_details": {
                 "company_name": "some company plc",
-                "company_address": "some place plc",
+                "updated_address": "some place plc",
                 "first_name": "John",
                 "last_name": "Smith",
                 "position_in_company": "a director",

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -241,13 +241,69 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
                    "last_name": "Man",
                    "contact_number": "012345678",
                    "email": "test.man@example.org",
-                   "correct_address": True,
+                   "correct_address": "True",
                    "date_of_birth_0": "12",
                    "date_of_birth_1": "03",
                    "date_of_birth_2": "1980"},
                   self.request_context)
         response = form.render()
         self.assertEqual(response.status_code, 302)
+
+    def test_your_details_stage_updated_address_required(self):
+        form = PleaOnlineForms("your_details", "plea_form_step", self.session)
+        form.load(self.request_context)
+
+        form_data = {"first_name": "Test",
+                     "last_name": "Man",
+                     "contact_number": "012345678",
+                     "email": "test.man@example.org",
+                     "correct_address": "False",
+                     "date_of_birth_0": "12",
+                     "date_of_birth_1": "03",
+                     "date_of_birth_2": "1980"}
+
+        form.save(form_data, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("updated_address", form.current_stage.forms[0].errors)
+        self.assertEqual(len(form.current_stage.forms[0].errors), 1)
+
+        form_data.update({"updated_address": "Test address"})
+        form.save(form_data, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(response.status_code, 302)
+
+    def test_company_details_stage_updated_address_required(self):
+        form = PleaOnlineForms("company_details", "plea_form_step", self.session)
+        form.load(self.request_context)
+
+        form_data = {"company_name": "Test Company",
+                     "correct_address": "False",
+                     "first_name": "John",
+                     "last_name": "Smith",
+                     "position_in_company": "Director",
+                     "contact_number": "07000000000",
+                     "email": "test@example.com"}
+
+        form.save(form_data, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("updated_address", form.current_stage.forms[0].errors)
+        self.assertEqual(len(form.current_stage.forms[0].errors), 1)
+
+        form_data.update({"updated_address": "Test address"})
+        form.save(form_data, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(response.status_code, 302)
+
 
     def test_plea_form_shows_errors_when_invalid(self):
         self.session.update({"case": {"complete": True,
@@ -883,7 +939,7 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
                    "last_name": "Brown",
                    "contact_number": "07802639892",
                    "email": "test@example.org",
-                   "correct_address": True,
+                   "correct_address": "True",
                    "date_of_birth_0": "12",
                    "date_of_birth_1": "03",
                    "date_of_birth_2": "1980"},
@@ -956,7 +1012,7 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
                    "last_name": "Brown",
                    "contact_number": "07802639892",
                    "email": "test@example.org",
-                   "correct_address": True,
+                   "correct_address": "True",
                    "date_of_birth_0": "12",
                    "date_of_birth_1": "03",
                    "date_of_birth_2": "1980"},

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -666,7 +666,7 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
             },
             "company_details": {
                 "company_name": "TEST COMPANY",
-                "company_address": "TEST ADDRESS",
+                "updated_address": "TEST ADDRESS",
                 "first_name": "TEST",
                 "last_name": "NAME",
                 "position_in_company": "a director",
@@ -727,7 +727,7 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
             },
             "company_details": {
                 "company_name": "TEST COMPANY",
-                "company_address": "TEST ADDRESS",
+                "updated_address": "TEST ADDRESS",
                 "first_name": "TEST",
                 "last_name": "NAME",
                 "position_in_company": "a director",

--- a/manchester_traffic_offences/templates/plea/company_details.html
+++ b/manchester_traffic_offences/templates/plea/company_details.html
@@ -44,7 +44,12 @@
 
         {% std_field form.company_name %}
 
-        {% std_field form.company_address %}
+        {% std_field form.correct_address %}
+
+        <div class="form-group-wide move-up js-Conditional" data-conditional-trigger="correct_address" data-conditional-value="False">
+            <h4 class="heading-small js-hidden">{% trans "If you answered \"No\":" %}</h4>
+            {% std_field form.updated_address hide_optional=True %}
+        </div>
 
         {% std_field form.first_name %}
 

--- a/manchester_traffic_offences/templates/plea/review/details.html
+++ b/manchester_traffic_offences/templates/plea/review/details.html
@@ -47,7 +47,7 @@
         </tr>
         <tr>
             <th>{% trans "Company address" %}</th>
-            <td>{{ company_details.company_address|linebreaksbr }}</td>
+            <td>{% if company_details.correct_address %}{% trans "As printed on Postal Requisition" %}{% else %}{{ company_details.updated_address|linebreaksbr }}{% endif %}</td>
         </tr>
         <tr>
             <th>{% trans "First name" %}</th>


### PR DESCRIPTION
Updated Company rep journey address input to match pattern used for Defendant journey: first a question whether address on requisition pack is correct, with an extra field to add updated address if not.

Error messages for Company rep journey based on Defendant journey messages.

New tests added for Company rep journey, also added to Defendant journey as these weren't present.