### PR TITLE
Added court field, migrations and updated tests.

### DIFF
--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from apps.plea.models import UsageStats, Court, Case, CaseAction
+from apps.plea.models import UsageStats, Court, Case, CaseAction, CourtEmailCount
 
 
 class UsageStatsAdmin(admin.ModelAdmin):
@@ -24,7 +24,12 @@ class CaseAdmin(admin.ModelAdmin):
     inlines = [InlineCaseAction,]
     search_fields = ["urn"]
 
+class CourtEmailCountAdmin(admin.ModelAdmin):
+    list_display = ("court", "total_pleas", "total_guilty", "total_not_guilty", "hearing_date", "sent", "processed")
+    model = CourtEmailCount
+
 
 admin.site.register(UsageStats, UsageStatsAdmin)
 admin.site.register(Court, CourtAdmin)
+admin.site.register(CourtEmailCount, CourtEmailCountAdmin)
 admin.site.register(Case, CaseAdmin)

--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -61,7 +61,7 @@ def send_plea_email(context_data):
     if not court_obj.test_mode:
         # don't add test court entries to the anon stat data
         email_count = CourtEmailCount()
-        email_count.get_from_context(context_data)
+        email_count.get_from_context(context_data, court=court_obj)
         email_count.save()
 
         email_count_id = email_count.id

--- a/apps/plea/migrations/0003_courtemailcount_court.py
+++ b/apps/plea/migrations/0003_courtemailcount_court.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0002_auto_20150518_1537'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courtemailcount',
+            name='court',
+            field=models.ForeignKey(default=1, to='plea.Court'),
+            preserve_default=False,
+        ),
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -126,6 +126,8 @@ class CourtEmailCountManager(models.Manager):
 
 class CourtEmailCount(models.Model):
     date_sent = models.DateTimeField(auto_now_add=True)
+    court = models.ForeignKey("Court")
+
     total_pleas = models.IntegerField()
     total_guilty = models.IntegerField()
     total_not_guilty = models.IntegerField()
@@ -144,7 +146,7 @@ class CourtEmailCount(models.Model):
         self.sent = case_obj.sent
         self.processed = case_obj.processed
 
-    def get_from_context(self, context):
+    def get_from_context(self, context, court):
         if "plea" not in context:
             return
         if "PleaForms" not in context["plea"]:
@@ -162,6 +164,8 @@ class CourtEmailCount(models.Model):
 
         if self.total_not_guilty is None:
             self.total_not_guilty = 0
+
+        self.court = court
 
         try:
             if isinstance(context["case"]["date_of_hearing"], dt.date):

--- a/apps/plea/tests/test_models.py
+++ b/apps/plea/tests/test_models.py
@@ -3,10 +3,23 @@ import datetime as dt
 
 from django.test import TestCase
 
-from ..models import CourtEmailCount, UsageStats
+from ..models import CourtEmailCount, UsageStats, Court
 
 
 class CourtEmailCountModelTestCase(TestCase):
+    def setUp(self):
+
+        self.court = Court.objects.create(
+            court_code="0000",
+            region_code="06",
+            court_name="test court",
+            court_address="test address",
+            court_telephone="0800 MAKEAPLEA",
+            court_email="test@test.com",
+            submission_email=True,
+            plp_email="test@test.com",
+            enabled=True,
+            test_mode=False)
 
     def test_get_from_context_hearing_date_is_combined_date_and_time(self):
         context = {
@@ -22,9 +35,8 @@ class CourtEmailCountModelTestCase(TestCase):
                 "date_of_hearing": "2014-09-22"
             }
         }
-
         emailcount = CourtEmailCount()
-        emailcount.get_from_context(context)
+        emailcount.get_from_context(context, self.court)
 
         self.assertEqual(emailcount.hearing_date, dt.datetime(2014, 9, 22, 0, 0, 0))
 
@@ -34,17 +46,20 @@ class CourtEmailCountModelTestCase(TestCase):
         """
         now = dt.datetime.today()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
@@ -77,17 +92,20 @@ class CourtEmailCountModelTestCase(TestCase):
     def test_get_stats_last_week(self):
         now = dt.datetime.today()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
 
-        CourtEmailCount(total_pleas=2,
+        CourtEmailCount(court=self.court,
+                        total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=now).save()
@@ -116,19 +134,22 @@ class CourtEmailCountModelTestCase(TestCase):
 
         tomorrow = dt.datetime.today() + dt.timedelta(1)
 
-        CourtEmailCount(date_sent=tomorrow,
+        CourtEmailCount(court=self.court,
+                        date_sent=tomorrow,
                         total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=tomorrow).save()
 
-        CourtEmailCount(date_sent=tomorrow,
+        CourtEmailCount(court=self.court,
+                        date_sent=tomorrow,
                         total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
                         hearing_date=tomorrow).save()
 
-        CourtEmailCount(date_sent=tomorrow,
+        CourtEmailCount(court=self.court,
+                        date_sent=tomorrow,
                         total_pleas=2,
                         total_guilty=1,
                         total_not_guilty=1,
@@ -171,19 +192,31 @@ class CourtEmailCountModelTestCase(TestCase):
 
         email_count = CourtEmailCount()
 
-        email_count.get_from_context(context)
+        email_count.get_from_context(context, self.court)
 
         self.assertEqual(email_count.sc_guilty_char_count, 13)
         self.assertEqual(email_count.sc_not_guilty_char_count, 16)
 
 class UsageStatsTestCase(TestCase):
-
     def setUp(self):
+        self.court = Court.objects.create(
+            court_code="0000",
+            region_code="06",
+            court_name="test court",
+            court_address="test address",
+            court_telephone="0800 MAKEAPLEA",
+            court_email="test@test.com",
+            submission_email=True,
+            plp_email="test@test.com",
+            enabled=True,
+            test_mode=False)
+
         # wednesday
         self.to_date = dt.date(2015, 01, 21)
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 50
         obj.total_guilty = 25
         obj.total_not_guilty = 5
@@ -192,6 +225,7 @@ class UsageStatsTestCase(TestCase):
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 50
         obj.total_guilty = 25
         obj.total_not_guilty = 5
@@ -200,6 +234,7 @@ class UsageStatsTestCase(TestCase):
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 50
         obj.total_guilty = 25
         obj.total_not_guilty = 5
@@ -208,6 +243,7 @@ class UsageStatsTestCase(TestCase):
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 50
         obj.total_guilty = 25
         obj.total_not_guilty = 5
@@ -216,6 +252,7 @@ class UsageStatsTestCase(TestCase):
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 100
         obj.total_guilty = 50
         obj.total_not_guilty = 5
@@ -224,6 +261,7 @@ class UsageStatsTestCase(TestCase):
 
         # should be included in entry with start_date of 5/01/2015
         obj = CourtEmailCount()
+        obj.court = self.court
         obj.total_pleas = 100
         obj.total_guilty = 50
         obj.total_not_guilty = 5

--- a/apps/receipt/tests.py
+++ b/apps/receipt/tests.py
@@ -85,7 +85,21 @@ class TestProcessReceipts(TestCase):
             sent=True,
             processed=False)
 
+        self.court = Court.objects.create(
+            court_code="51",
+            region_code="06",
+            court_name="whatever",
+            court_address="asdf",
+            enabled=True,
+            court_telephone="00000",
+            court_email="test@test.com",
+            submission_email="",
+            court_receipt_email="sending@test.com",
+            local_receipt_email="incoming@test.com",
+            test_mode=False)
+
         self.email_count = CourtEmailCount.objects.create(
+            court=self.court,
             hearing_date=self.doh,
             total_pleas=1,
             total_guilty=1,
@@ -289,20 +303,6 @@ class WebHookTestCase(TestCase):
             sent=True,
             processed=False)
 
-        self.email_count = CourtEmailCount.objects.create(
-            hearing_date=self.doh,
-            total_pleas=1,
-            total_guilty=1,
-            total_not_guilty=0,
-            sent=True,
-            processed=False)
-
-        self.email_body_valid = """
-        Random content.
-        <<<makeaplea-ref: {}/{}>>>
-        Random content.
-        """.format(self.case.id, self.email_count.id)
-
         self.court = Court.objects.create(
             court_code="51",
             region_code="06",
@@ -315,6 +315,21 @@ class WebHookTestCase(TestCase):
             court_receipt_email="sending@test.com",
             local_receipt_email="incoming@test.com",
             test_mode=False)
+
+        self.email_count = CourtEmailCount.objects.create(
+            hearing_date=self.doh,
+            court=self.court,
+            total_pleas=1,
+            total_guilty=1,
+            total_not_guilty=0,
+            sent=True,
+            processed=False)
+
+        self.email_body_valid = """
+        Random content.
+        <<<makeaplea-ref: {}/{}>>>
+        Random content.
+        """.format(self.case.id, self.email_count.id)
 
     def _get_mandrill_post_data(self, subject=None, text=None, from_email=None, email=None):
         return {


### PR DESCRIPTION
With the application now able to take pleas in different areas it
has been noted that the anon stats should be able to break down
by the area in which the plea was made.

This commit adds a field for court into the anon stats model and
updates the application code and tests to pass in court where
required.

[MAPDEV281]