### PR TITLE
Hotfix non js redirect error

### DIFF
--- a/apps/govuk_utils/stages.py
+++ b/apps/govuk_utils/stages.py
@@ -92,15 +92,15 @@ class FormStage(object):
         self.nojs = form_data.get("nojs", None)
 
         clean_data["nojs"] = self.nojs
-        
-        # self.all_data[self.name].pop("complete", None)
 
         if self.form and self.form.is_valid():
             clean_data.update(self.save_forms())
+            
             if self.nojs is None or self.nojs == "nojs_last_step":
                 clean_data["complete"] = True
                 self.next_step = self.get_next(next_step)
             else:
+                self.all_data[self.name].pop("complete", None)
                 self.form.data["nojs"] = "nojs_last_step"
                 clean_data["nojs"] = "nojs_last_step"
         

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -203,16 +203,17 @@ class YourMoneyStage(FormStage):
 
         you_are = clean_data.get('you_are', None)
 
-        if you_are:
+        if self.nojs is None or self.nojs == "nojs_last_step":
+            if you_are:
 
-            hardship_field = you_are.replace(' ', '_').replace('-', '_').lower() + "_hardship"
+                hardship_field = you_are.replace(' ', '_').replace('-', '_').lower() + "_hardship"
 
-            hardship = clean_data.get(hardship_field, False)
+                hardship = clean_data.get(hardship_field, False)
 
-            self.all_data["your_finances"]["hardship"] = hardship
+                self.all_data["your_finances"]["hardship"] = hardship
 
-            if not hardship:
-                self.set_next_step("review", skip=["your_expenses"])
+                if not hardship:
+                    self.set_next_step("review", skip=["your_expenses"])
 
         return clean_data
 

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -267,8 +267,8 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
         response = form.render()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("updated_address", form.current_stage.forms[0].errors)
-        self.assertEqual(len(form.current_stage.forms[0].errors), 1)
+        self.assertIn("updated_address", form.current_stage.form.errors)
+        self.assertEqual(len(form.current_stage.form.errors), 1)
 
         form_data.update({"updated_address": "Test address"})
         form.save(form_data, self.request_context)
@@ -294,8 +294,8 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
         response = form.render()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("updated_address", form.current_stage.forms[0].errors)
-        self.assertEqual(len(form.current_stage.forms[0].errors), 1)
+        self.assertIn("updated_address", form.current_stage.form.errors)
+        self.assertEqual(len(form.current_stage.form.errors), 1)
 
         form_data.update({"updated_address": "Test address"})
         form.save(form_data, self.request_context)


### PR DESCRIPTION
If the hardship question wasn't answered (which is the case
in the first step of the NoJS journey), the stage was redirecting
to the review screen, which in the case of the NoJS journey
is incorrect.

We are now resetting the `Complete` flag for each step when a
NoJS POST is done. This will prevent users from being able to
navigate back to the `Review` screen by updating the URL directly
after only updating the first step of a NoJS question.

Also fixed a bad reference to multiple forms construct in new 'updated address' tests.