### PR TITLE
Mapdev311 dob validation

### DIFF
--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -108,28 +108,27 @@ def is_urn_valid(urn):
     pattern = r"[0-9]{2}/[a-zA-Z]{2}/(?:[0-9]{5}|[0-9]{7})/[0-9]{2}"
 
     if not re.match(pattern, urn) or not Court.objects.has_court(urn):
-        raise exceptions.ValidationError(_(ERROR_MESSAGES["URN_INVALID"]))
+        raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
 
     return True
 
 
 def is_date_in_past(date):
     if date >= datetime.datetime.today().date():
-        raise exceptions.ValidationError(ERROR_MESSAGES["DATE_OF_BIRTH_IN_FUTURE"], code="is_date_in_past")
+        raise exceptions.ValidationError("The date must be in the past", code="is_date_in_past")
 
     return True
 
 def is_date_in_future(date):
     if date <= datetime.datetime.today().date():
-        raise exceptions.ValidationError(ERROR_MESSAGES["HEARING_DATE_PASSED"])
+        raise exceptions.ValidationError("The date must be in the future", code="is_date_in_future")
 
     return True
 
 
 def is_date_within_range(date):
-
     if date > datetime.datetime.today().date()+datetime.timedelta(178):
-        raise exceptions.ValidationError(ERROR_MESSAGES["HEARING_DATE_INCORRECT"])
+        raise exceptions.ValidationError("The date must be within the next 6 months", code="is_date_within_range")
 
     return True
 
@@ -140,8 +139,7 @@ def is_urn_not_used(urn):
     """
 
     if not Case.objects.can_use_urn(urn):
-        raise exceptions.ValidationError(
-            _(ERROR_MESSAGES['URN_ALREADY_USED']))
+        raise exceptions.ValidationError("The URN has already been used", code="is_urn_not_used")
 
     return True
 

--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -38,6 +38,7 @@ ERROR_MESSAGES = {
     "CONTACT_NUMBER_INVALID": _("The contact number isn't a valid format"),
     "DATE_OF_BIRTH_REQUIRED": _("Enter your date of birth"),
     "DATE_OF_BIRTH_INVALID": _("The date of birth isn't a valid format"),
+    "DATE_OF_BIRTH_IN_FUTURE": _("The date of birth must be before today"),
     "COMPANY_NAME_REQUIRED": _("Enter the company name"),
     "COMPANY_ADDRESS_REQUIRED": _("Enter the company address"),
     "POSITION_REQUIRED": _("Confirm your position in the company"),
@@ -111,6 +112,12 @@ def is_urn_valid(urn):
 
     return True
 
+
+def is_date_in_past(date):
+    if date >= datetime.datetime.today().date():
+        raise exceptions.ValidationError(ERROR_MESSAGES["DATE_OF_BIRTH_IN_FUTURE"], code="is_date_in_past")
+
+    return True
 
 def is_date_in_future(date):
     if date <= datetime.datetime.today().date():

--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -25,7 +25,7 @@ ERROR_MESSAGES = {
     "HEARING_DATE_PASSED": _("The court hearing date must be after today"),
     "HEARING_DATE_INCORRECT": _("Enter the correct hearing date"),
     "NUMBER_OF_CHARGES_REQUIRED": _("Select the number of charges against you"),
-    "PLEA_MADE_BY_REQUIRED": _("You must tell us if you are the person named in the postal requisition or pleading on behalf of a company"),
+    "PLEA_MADE_BY_REQUIRED": _("You must tell us if you are the person named in the requisition pack or pleading on behalf of a company"),
     "FIRST_NAME_REQUIRED": _("Enter your first name"),
     "LAST_NAME_REQUIRED": _("Enter your last name"),
     "CORRECT_ADDRESS_REQUIRED": _("Tell us if your address on the requisition pack is correct "),

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -6,7 +6,7 @@ from django.forms.widgets import Textarea, RadioSelect
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from .fields import (ERROR_MESSAGES, is_date_in_future, is_date_within_range,
+from .fields import (ERROR_MESSAGES, is_date_in_past, is_date_in_future, is_date_within_range,
                      DSRadioFieldRenderer,
                      DSStackedRadioFieldRenderer,
                      URNField,
@@ -137,17 +137,17 @@ class YourDetailsForm(BasePleaStepForm):
                                 error_messages={"required": ERROR_MESSAGES["LAST_NAME_REQUIRED"]})
 
     correct_address = forms.TypedChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),
-                                              required=True,
-                                              coerce=to_bool,
-                                              choices=YESNO_CHOICES,
-                                              label=_("Is your address on the requisition pack correct?"),
-                                              error_messages={"required": ERROR_MESSAGES["CORRECT_ADDRESS_REQUIRED"]})
+                                             required=True,
+                                             coerce=to_bool,
+                                             choices=YESNO_CHOICES,
+                                             label=_("Is your address on the requisition pack correct?"),
+                                             error_messages={"required": ERROR_MESSAGES["CORRECT_ADDRESS_REQUIRED"]})
 
     updated_address = forms.CharField(widget=forms.Textarea(attrs={"rows": "4", "class": "form-control"}),
-                                  required=False,
-                                  label="",
-                                  help_text=_("If your address is different from the one shown on page 1 of the requisition pack, tell us here:"),
-                                  error_messages={"required": ERROR_MESSAGES["UPDATED_ADDRESS_REQUIRED"]})
+                                      required=False,
+                                      label="",
+                                      help_text=_("If your address is different from the one shown on page 1 of the requisition pack, tell us here:"),
+                                      error_messages={"required": ERROR_MESSAGES["UPDATED_ADDRESS_REQUIRED"]})
 
     contact_number = forms.CharField(widget=forms.TextInput(attrs={"type": "tel", "class": "form-control"}),
                                      required=True,
@@ -166,9 +166,11 @@ class YourDetailsForm(BasePleaStepForm):
 
     date_of_birth = forms.DateField(widget=DateWidget,
                                     required=True,
+                                    validators=[is_date_in_past],
                                     label=_("Date of birth"),
                                     error_messages={"required": ERROR_MESSAGES["DATE_OF_BIRTH_REQUIRED"],
-                                                    "invalid": ERROR_MESSAGES["DATE_OF_BIRTH_INVALID"]})
+                                                    "invalid": ERROR_MESSAGES["DATE_OF_BIRTH_INVALID"],
+                                                    "is_date_in_past": ERROR_MESSAGES["DATE_OF_BIRTH_IN_FUTURE"]})
 
     ni_number = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
                                 required=False,

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -96,9 +96,11 @@ class CaseForm(BasePleaStepForm):
 
     urn = URNField(label=_("Unique reference number (URN)"),
                    required=True,
+                   validators=[is_urn_valid, is_urn_not_used],
                    help_text=_("On page 1 of the pack, in the top right corner.<br>For example, 12/AB/34567/00"),
-                   error_messages={"required": ERROR_MESSAGES["URN_REQUIRED"]},
-                   validators=[is_urn_valid, is_urn_not_used])
+                   error_messages={"required": ERROR_MESSAGES["URN_REQUIRED"],
+                                   "is_urn_valid": ERROR_MESSAGES["URN_INVALID"],
+                                   "is_urn_not_used": ERROR_MESSAGES['URN_ALREADY_USED']})
 
     date_of_hearing = forms.DateField(widget=DateWidget,
                                       validators=[is_date_in_future, is_date_within_range],
@@ -106,7 +108,9 @@ class CaseForm(BasePleaStepForm):
                                       label=_("Court hearing date"),
                                       help_text=_("On page 1 of the pack, near the top on the left.<br>For example, 30/07/2014"),
                                       error_messages={"required": ERROR_MESSAGES["HEARING_DATE_REQUIRED"],
-                                                      "invalid": ERROR_MESSAGES["HEARING_DATE_INVALID"]})
+                                                      "invalid": ERROR_MESSAGES["HEARING_DATE_INVALID"],
+                                                      "is_date_in_future": ERROR_MESSAGES["HEARING_DATE_PASSED"],
+                                                      "is_date_within_range": ERROR_MESSAGES["HEARING_DATE_INCORRECT"]})
 
     number_of_charges = forms.IntegerField(label=_("Number of charges against you"),
                                            widget=forms.TextInput(attrs={"pattern": "[0-9]*",

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -207,7 +207,7 @@ class CompanyDetailsForm(BasePleaStepForm):
                                    widget=forms.TextInput(attrs={"class": "form-control"}),
                                    max_length=100,
                                    required=True,
-                                   help_text=_("As written on page 1 of the Postal Requistion we sent you."),
+                                   help_text=_("As written on page 1 of the requisition pack we sent you."),
                                    error_messages={"required": ERROR_MESSAGES["COMPANY_NAME_REQUIRED"]})
 
     correct_address = forms.TypedChoiceField(widget=RadioSelect(renderer=DSRadioFieldRenderer),


### PR DESCRIPTION
Add validator to prevent entering dates in the future.

Also tidied up existing custom validators to move the error messages to the form schema, alongside where all other error messages are set. Default error messages in the validators themselves now make more sense in context, and are more generic.

Fix one remaining occurrence of 'postal requisition'.