### PR TITLE
Courts can now be switched to use URN validation

### DIFF
--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -48,9 +48,12 @@ def send_plea_email(context_data):
     context_data["email_name"] = " ".join([last_name.upper(), first_name])
     context_data["email_date_of_hearing"] = date_of_hearing.strftime("%Y-%m-%d")
 
-    case = Case()
-    case.urn = context_data["case"]["urn"].upper()
-    case.save()
+    # Get or create case
+    try:
+        case = Case.objects.get(urn__iexact=context_data["case"]["urn"].upper(), sent=False)
+    except Case.DoesNotExist:
+        case = Case(urn=context_data["case"]["urn"].upper(), sent=False)
+        case.save()
 
     if "court" in context_data:
         del context_data["court"]

--- a/apps/plea/fields.py
+++ b/apps/plea/fields.py
@@ -109,6 +109,10 @@ def is_urn_valid(urn):
     if not re.match(pattern, urn) or not Court.objects.has_court(urn):
         raise exceptions.ValidationError(_(ERROR_MESSAGES["URN_INVALID"]))
 
+    court = Court.objects.get_by_urn(urn)
+    if court.validate_urn and not Case.objects.filter(urn__iexact=urn, sent=False).exists():
+        raise exceptions.ValidationError(_(ERROR_MESSAGES["URN_INVALID"]))
+
     return True
 
 

--- a/apps/plea/migrations/0004_court_validate_urn.py
+++ b/apps/plea/migrations/0004_court_validate_urn.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0003_courtemailcount_court'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='court',
+            name='validate_urn',
+            field=models.BooleanField(default=False, help_text=b'Do we have a full set of incoming DX data?'),
+        ),
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -409,6 +409,11 @@ class Court(models.Model):
         default=False,
         help_text="Is this court entry used for testing purposes?")
 
+    validate_urn = models.BooleanField(
+        default=False,
+        help_text="Do we have a full set of incoming DX data?"
+    )
+
     def __unicode__(self):
         return "{} / {} / {}".format(self.court_code,
                                      self.region_code,

--- a/apps/plea/tests/test_validators.py
+++ b/apps/plea/tests/test_validators.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from django import forms
+from django.forms import ValidationError
 
-from ..models import Court
+from ..models import Court, Case
 from ..fields import is_urn_valid
 
 
@@ -20,6 +21,22 @@ class UtilsTestCase(TestCase):
             plp_email="test@test.com",
             enabled=True,
             test_mode=False)
+
+    def test_urn_valid_database(self):
+        self.court.validate_urn = True
+        self.court.save()
+
+        case = Case(urn="06/QQ/00000/00", sent=False)
+        case.save()
+
+        self.assertTrue(is_urn_valid("06/QQ/00000/00"))
+
+    def test_urn_invalid_database(self):
+        self.court.validate_urn = True
+        self.court.save()
+
+        with self.assertRaises(ValidationError):
+            is_urn_valid("06/QQ/00000/01")
 
     def test_is_valid_urn_format(self):
         good_urns = [


### PR DESCRIPTION
Individual courts can now be switched on to ensure the case record is
present in the database before proceeding.

Added option for court in model and updated validator.

[MAPDEV207]