### PR TITLE
Amends made to case and offence model fields for DX

### DIFF
--- a/apps/plea/migrations/0002_auto_20150602_1636.py
+++ b/apps/plea/migrations/0002_auto_20150602_1636.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='offence',
+            name='offence_short_title',
+            field=models.CharField(max_length=120),
+        ),
+    ]

--- a/apps/plea/migrations/0003_auto_20150602_1658.py
+++ b/apps/plea/migrations/0003_auto_20150602_1658.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0002_auto_20150602_1636'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='case',
+            name='case_number',
+            field=models.CharField(help_text=b'as supplied by DX', max_length=12, null=True, blank=True),
+        ),
+    ]

--- a/apps/plea/migrations/0004_merge.py
+++ b/apps/plea/migrations/0004_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0002_auto_20150518_1537'),
+        ('plea', '0003_auto_20150602_1658'),
+    ]
+
+    operations = [
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -254,7 +254,7 @@ class Offence(models.Model):
     case = models.ForeignKey(Case, related_name="offences")
 
     offence_code = models.CharField(max_length=10, null=True, blank=True)
-    offence_short_title = models.CharField(max_length=100)
+    offence_short_title = models.CharField(max_length=120)
     offence_wording = models.TextField(max_length=4000)
     offence_seq_number = models.CharField(max_length=10, null=True, blank=True)
 


### PR DESCRIPTION
A few minor field amends have been made to accommodate the DX integration: 

1) the case_number and offence_short_title fields have had been altered to match the char length values in the dx/libra case xsd

2) the ou code has been moved from the offence model to the case model, where it belongs.

I had a migration clash, which seemed to resolve when I ran ./manage makemigrations --merge. If it persists when deployed to dev/staging, I'll manually merge the migrations into a single file.