### PR TITLE
MAPDEV280 Added django-celery task backend to enable failed tasks to retry

### DIFF
--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -19,7 +19,7 @@ from apps.plea.models import Case, CourtEmailCount, Court
 logger = logging.getLogger(__name__)
 
 
-@app.task(bind=True, max_retries=5, default_retry_delay=90)
+@app.task(bind=True, max_retries=5)
 def email_send_court(self, case_id, count_id, email_data):
     smtp_route = "GSI"
 
@@ -32,6 +32,7 @@ def email_send_court(self, case_id, count_id, email_data):
         logger.error("URN does not have a matching Court entry: {}".format(
             email_data["case"]["urn"]))
         raise
+
 
     plea_email_to = [court_obj.submission_email]
 
@@ -76,7 +77,7 @@ def email_send_court(self, case_id, count_id, email_data):
     email_send_user.delay(email_data, case_id)
 
 
-@app.task(bind=True, max_retries=5, default_retry_delay=90)
+@app.task(bind=True, max_retries=5)
 def email_send_prosecutor(self, email_data, case_id):
     smtp_route = "PNN"
 
@@ -115,7 +116,7 @@ def email_send_prosecutor(self, email_data, case_id):
     return True
 
 
-@app.task(bind=True, max_retries=5, default_retry_delay=90)
+@app.task(bind=True, max_retries=5)
 def email_send_user(self, email_data, case_id):
     """
     Dispatch an email to the user to confirm that their plea submission

--- a/manchester_traffic_offences/celery.py
+++ b/manchester_traffic_offences/celery.py
@@ -9,6 +9,5 @@ if not os.environ.has_key("DJANGO_SETTINGS_MODULE"):
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'manchester_traffic_offences.settings.local')
 
 app = Celery('apps.plea')
-
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/manchester_traffic_offences/settings/base.py
+++ b/manchester_traffic_offences/settings/base.py
@@ -167,6 +167,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'django_extensions',
+    'djcelery',
     'waffle',
     'apps.govuk_utils',
     'moj_template',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ sh==1.11
 django_extensions==1.5.3
 django-brake==1.3.1
 django-waffle==0.10.1
+django-celery==3.1.16
 djangorestframework==3.1.2
 
 # MOJ Template


### PR DESCRIPTION
The retry on failed tasks was happening immediately instead of
delaying 90 seconds as required. This was due to the tasks results
being discarded. A django-orm backend has been added as a first
pass with the option of moving it to redis or a cache later.

[MAPDEV280]