### PR TITLE
Add end-of-journey analytics

### DIFF
--- a/manchester_traffic_offences/templates/plea/complete.html
+++ b/manchester_traffic_offences/templates/plea/complete.html
@@ -78,3 +78,15 @@
     </section>
     
 {% endblock page_content %}
+
+{% block body_end %}
+    {{ block.super }}
+
+    {% if analytics_events %}
+<script>
+{% for event in analytics_events %}
+ga('send', 'event', 'Complete submission', '{{ event.action }}', '{{ event.label }}');
+{% endfor %}
+</script>
+    {% endif %}
+{% endblock body_end %}


### PR DESCRIPTION
These add new GA events at the end of a journey (on the Complete screen).

For all journeys:
- Complete submission: Plea made by (Defendant/Company representative)

For 'Defendant' journeys:
- Complete submission: NI number (yes/no)
- Complete submission: Driving licence number (yes/no)

[MAPDEV345]