### PR TITLE
Fix language of Court and Police emails

### DIFF
--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -10,6 +10,7 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.mail import get_connection
 from django.conf import settings
 from django.template.loader import render_to_string
+from django.utils import translation
 from django.utils.text import wrap
 
 from apps.govuk_utils.email import TemplateAttachmentEmail
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @app.task(bind=True, max_retries=5)
+@translation.override("en")
 def email_send_court(self, case_id, count_id, email_data):
     smtp_route = "GSI"
 
@@ -76,6 +78,7 @@ def email_send_court(self, case_id, count_id, email_data):
 
 
 @app.task(bind=True, max_retries=5)
+@translation.override("en")
 def email_send_prosecutor(self, case_id, email_data):
     smtp_route = "PNN"
 

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -158,7 +158,7 @@ class EmailTemplateTests(TestCase):
         self.assertContains(response, "<tr><th>Court hearing date</th><td>{}</td></tr>".format(self.hearing_date.strftime('%d/%m/%Y')), count=1, html=True)
 
     def test_case_details_output_is_english(self):
-        translation.activate("en")
+        translation.activate("cy")
 
         context_data = self.get_context_data()
 

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -6,6 +6,7 @@ from mock import Mock
 from django.core import mail
 from django.forms.formsets import formset_factory
 from django.test import TestCase
+from django.utils import translation
 
 from ..email import send_plea_email
 from ..models import Court
@@ -152,6 +153,20 @@ class EmailTemplateTests(TestCase):
         send_plea_email(context_data)
 
         response = self.get_mock_response(mail.outbox[0].attachments[0][1])
+
+        self.assertContains(response, "<tr><th>Unique reference number</th><td>06/AA/00000/00</td></tr>", count=1, html=True)
+        self.assertContains(response, "<tr><th>Court hearing date</th><td>{}</td></tr>".format(self.hearing_date.strftime('%d/%m/%Y')), count=1, html=True)
+
+    def test_case_details_output_is_english(self):
+        translation.activate("en")
+
+        context_data = self.get_context_data()
+
+        send_plea_email(context_data)
+
+        response = self.get_mock_response(mail.outbox[0].attachments[0][1])
+
+        translation.deactivate()
 
         self.assertContains(response, "<tr><th>Unique reference number</th><td>06/AA/00000/00</td></tr>", count=1, html=True)
         self.assertContains(response, "<tr><th>Court hearing date</th><td>{}</td></tr>".format(self.hearing_date.strftime('%d/%m/%Y')), count=1, html=True)
@@ -435,15 +450,20 @@ class EmailTemplateTests(TestCase):
         send_plea_email(context_data)
 
         response = self.get_mock_response(mail.outbox[1].attachments[0][1])
-        self.assertContains(response, "<tr><th>URN</th><td>06/AA/00000/00</td></tr>", count=1, html=True)
-        self.assertContains(response, "<tr><th>Court hearing</th><td>30 October 2015</td></tr>", count=1, html=True)
+        self.assertContains(response, "<tr><th>First name</th><td>Joe</td></tr>", count=1, html=True)
+        self.assertContains(response, "<tr><th>Last name</th><td>Public</td></tr>", count=1, html=True)
 
-    def test_PLP_case_details_output(self):
+    def test_PLP_case_details_output_is_english(self):
+        translation.activate("cy")
+
         context_data = self.get_context_data()
 
         send_plea_email(context_data)
 
         response = self.get_mock_response(mail.outbox[1].attachments[0][1])
+
+        translation.deactivate()
+        
         self.assertContains(response, "<tr><th>First name</th><td>Joe</td></tr>", count=1, html=True)
         self.assertContains(response, "<tr><th>Last name</th><td>Public</td></tr>", count=1, html=True)
 


### PR DESCRIPTION
When a journey was entered using the Welsh language version of
the site, the resulting Court and Police emails were being sent in
Welsh.

Added a decorator to both Court and Police email senders to force
English language.

[MAPDEV378]