### PR TITLE
Add Welsh flag to emails for Welsh journeys

### DIFF
--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -8,8 +8,10 @@ from django.core.mail import EmailMultiAlternatives
 from django.core.mail import get_connection
 from django.conf import settings
 from django.template.loader import render_to_string
+from django.utils import translation
 
 from apps.govuk_utils.email import TemplateAttachmentEmail
+
 from .models import Case, CourtEmailCount, Court
 from .encrypt import encrypt_and_store_user_data
 from tasks import email_send_court, email_send_prosecutor, email_send_user
@@ -47,6 +49,10 @@ def send_plea_email(context_data):
 
     context_data["email_name"] = " ".join([last_name.upper(), first_name])
     context_data["email_date_of_hearing"] = date_of_hearing.strftime("%Y-%m-%d")
+
+    # Add Welsh flag if journey was completed in Welsh
+    if translation.get_language() == "cy":
+        context_data["welsh_language"] = True
 
     # Get or create case
     try:

--- a/apps/plea/templates/emails/attachments/plea_email.html
+++ b/apps/plea/templates/emails/attachments/plea_email.html
@@ -26,7 +26,8 @@
 
 <body>
 <h1>Online plea</h1>
-   <table class="review-table" id="case-details">
+
+    <table class="review-table" id="case-details">
     <thead>
         <tr>
             <th colspan="2">
@@ -145,5 +146,23 @@
             </tr>
         </tbody>
     </table>
+
+    {% if welsh_language %}
+    <table class="review-table" id="welsh_language">
+    <thead>
+        <tr>
+            <th colspan="2">
+                <h2>Plea language</h2>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>Welsh language</th>
+            <td>Yes</td>
+        </tr>
+    </tbody>
+    </table>
+    {% endif %}
 </body>
 </html>

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -171,6 +171,30 @@ class EmailTemplateTests(TestCase):
         self.assertContains(response, "<tr><th>Unique reference number</th><td>06/AA/00000/00</td></tr>", count=1, html=True)
         self.assertContains(response, "<tr><th>Court hearing date</th><td>{}</td></tr>".format(self.hearing_date.strftime('%d/%m/%Y')), count=1, html=True)
 
+    def test_welsh_journey_adds_welsh_flag(self):
+        translation.activate("cy")
+
+        context_data = self.get_context_data()
+
+        send_plea_email(context_data)
+
+        response = self.get_mock_response(mail.outbox[0].attachments[0][1])
+
+        translation.deactivate()
+
+        self.assertContains(response, "<tr><th>Welsh language</th><td>Yes</td></tr>", count=1, html=True)
+
+    def test_english_journey_adds_no_welsh_flag(self):
+        translation.activate("en")
+
+        context_data = self.get_context_data()
+
+        send_plea_email(context_data)
+
+        response = self.get_mock_response(mail.outbox[0].attachments[0][1])
+
+        self.assertNotContains(response, "<tr><th>Welsh language</th><td>Yes</td></tr>", html=True)
+
     def test_min_case_details_output(self):
         context_data = self.get_context_data()
 


### PR DESCRIPTION
For journeys completed using the Welsh version of the site,
this adds an extra section called 'Language' to the plea email.

[MAPDEV371]