### PR TITLE
Mapdev364 cookies

### DIFF
--- a/manchester_traffic_offences/settings/base.py
+++ b/manchester_traffic_offences/settings/base.py
@@ -146,10 +146,12 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'manchester_traffic_offences.urls'
 
 SESSION_SERIALIZER = 'apps.govuk_utils.serializers.DateAwareSerializer'
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = 'encrypted_cookies'
 SESSION_COOKIE_HTTPONLY = True
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 3600
+
+CSRF_COOKIE_HTTPONLY = True
 
 RATE_LIMIT = "20/m"
 

--- a/manchester_traffic_offences/settings/dev.py
+++ b/manchester_traffic_offences/settings/dev.py
@@ -39,3 +39,7 @@ ALLOWED_HOSTS = ["dev.makeaplea.dsd.io", ]
 
 # Enable CachedStaticFilesStorage for cache-busting assets
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
+
+ENCRYPTED_COOKIE_KEYS = [
+    os.environ["ENCRYPTED_COOKIE_KEY"]
+]

--- a/manchester_traffic_offences/settings/dev.py
+++ b/manchester_traffic_offences/settings/dev.py
@@ -40,6 +40,9 @@ ALLOWED_HOSTS = ["dev.makeaplea.dsd.io", ]
 # Enable CachedStaticFilesStorage for cache-busting assets
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
 ENCRYPTED_COOKIE_KEYS = [
     os.environ["ENCRYPTED_COOKIE_KEY"]
 ]

--- a/manchester_traffic_offences/settings/production.py
+++ b/manchester_traffic_offences/settings/production.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = ["www.makeaplea.justice.gov.uk", ]
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
 SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 STORE_USER_DATA = True
 

--- a/manchester_traffic_offences/settings/production.py
+++ b/manchester_traffic_offences/settings/production.py
@@ -35,3 +35,7 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStora
 SESSION_COOKIE_SECURE = True
 
 STORE_USER_DATA = True
+
+ENCRYPTED_COOKIE_KEYS = [
+    os.environ["ENCRYPTED_COOKIE_KEY"]
+]

--- a/manchester_traffic_offences/settings/staging.py
+++ b/manchester_traffic_offences/settings/staging.py
@@ -45,6 +45,11 @@ ALLOWED_HOSTS = ["staging.makeaplea.dsd.io", "makeaplea.dsd.io"]
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
 SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 STORE_USER_DATA = True
+
+ENCRYPTED_COOKIE_KEYS = [
+    os.environ["ENCRYPTED_COOKIE_KEY"]
+]
 

--- a/manchester_traffic_offences/settings/testing.py
+++ b/manchester_traffic_offences/settings/testing.py
@@ -31,6 +31,10 @@ GPG_RECIPIENT = "test@test.com"
 
 TEST_RUNNER = 'apps.plea.runner.MAPTestRunner'
 
+ENCRYPTED_COOKIE_KEYS = [
+    '9evXbsR_1yZA5EW_blSI4O69MjGKwOu1-UwLK_PWyKw=',
+]
+
 # a test gpg key with no passphrase and email test@test.com
 
 GPG_TEST_KEY = """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ psycopg2==2.5.4
 python-dateutil==2.4.2
 python-gnupg==0.3.7
 sh==1.11
+django-encrypted-cookie-session==3.0.0
 
 django_extensions==1.5.3
 django-brake==1.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,4 @@ celery[sqs]==3.1.17
 mock==1.0.1
 raven==5.3.1
 ipdb==0.8
-redgreenunittest
+redgreenunittest==0.1.1


### PR DESCRIPTION
Combines tickets MAPDEV364, MAPDEV367 and MAPDEV363

Set up encrypted cookies https://github.com/brightinteractive/django-encrypted-cookie-session

And added the CSRF_COOKIE_HTTPONLY and CSRF_COOKIE_SECURE flags to settings so now that both the session cookie and the csrf cookie are secure and httponly and the session cookie should now be both signed and encrypted.