### PR TITLE
Update Plea journey to use its own session key

### DIFF
--- a/apps/feedback/tests.py
+++ b/apps/feedback/tests.py
@@ -46,7 +46,7 @@ class FeedbackFormTestCase(TestCase):
         request.META["HTTP_USER_AGENT"] = "Test User Agent"
         return request
 
-    
+
     def test_service_stage_incomplete_data(self):
         form = FeedbackForms("service", "feedback_form_step", self.empty_session_data)
         form.load(self.request_context)
@@ -57,7 +57,7 @@ class FeedbackFormTestCase(TestCase):
     def test_service_stage_call_centre_used_incomplete_data(self):
         form = FeedbackForms("service", "feedback_form_step", self.empty_session_data)
         form.load(self.request_context)
-        
+
         save_data = {
             "used_call_centre": True
         }
@@ -93,7 +93,7 @@ class FeedbackFormTestCase(TestCase):
 
         form = FeedbackForms("comments", "feedback_form_step", session_data)
         form.load(self.request_context)
-        
+
         response = form.render()
         self.assertIn("Email address", response.content)
 
@@ -113,8 +113,7 @@ class FeedbackFormTestCase(TestCase):
         with self.assertTemplateUsed("comments.html"):
             response = form.render()
             self.assertNotIn("Email address", response.content)
-    
-    
+
     def test_email_is_sent(self):
         form = FeedbackForms("comments", "feedback_form_step", self.complete_session_data)
         form.save({}, self.request_context)
@@ -132,11 +131,11 @@ class FeedbackFormTestCase(TestCase):
 
         self.assertEquals(messages.add_message.call_count, 1)
 
-    
+
     def test_redirect_is_set(self):
         fake_request = self.get_request_mock("/feedback/?next=terms")
         fake_request.session = {}
-        fake_request.session["feedback"] = self.complete_session_data
+        fake_request.session["feedback_data"] = self.complete_session_data
 
         view = FeedbackViews()
         response = view.get(fake_request, stage="complete")

--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -26,13 +26,13 @@ class FeedbackViews(TemplateView):
         return super(FeedbackViews, self).dispatch(*args, **kwargs)
 
     def _get_storage(self, request):
-        if not request.session.get("feedback"):
-            request.session["feedback"] = {}
+        if not request.session.get("feedback_data"):
+            request.session["feedback_data"] = {}
 
-        return request.session["feedback"]
+        return request.session["feedback_data"]
 
     def _clear_storage(self, request):
-        del request.session["feedback"]
+        del request.session["feedback_data"]
 
     def get(self, request, stage=None):
         storage = self._get_storage(request)

--- a/apps/plea/middleware.py
+++ b/apps/plea/middleware.py
@@ -4,7 +4,7 @@ class TimeoutRedirectMiddleware:
 
     def process_response(self, request, response):
         try:
-            if (request.session.get('case', {}).get('urn', False)):
+            if (request.session.get("plea", {}).get("case", {}).get("urn", False)):
                 response["Refresh"] = str(getattr(settings, "SESSION_COOKIE_AGE", 3600)) + "; url=/session-timeout/"
         except AttributeError:
             pass

--- a/apps/plea/templates/plea.html
+++ b/apps/plea/templates/plea.html
@@ -5,7 +5,7 @@
 {% load filters %}
 
 {% spaceless %}
-{% block page_title %}{% include "partials/page_title_plea.html" with charges=request.session.case.number_of_charges %} - {{ block.super }}{% endblock %}    
+{% block page_title %}{% include "partials/page_title_plea.html" with charges=case.number_of_charges %} - {{ block.super }}{% endblock %}
 {% endspaceless %}
 
 
@@ -30,7 +30,7 @@
 
 {% block stage_header %}
     {% spaceless %}
-    <h1>{% include "partials/page_title_plea.html" with charges=request.session.case.number_of_charges %}</h1>
+    <h1>{% include "partials/page_title_plea.html" with charges=case.number_of_charges %}</h1>
     {% endspaceless %}
 
     {% if plea.split_form == "split_form_last_step" %}

--- a/apps/plea/tests/test_timeout.py
+++ b/apps/plea/tests/test_timeout.py
@@ -10,7 +10,7 @@ class TestTimeout(TestCase):
     def setUp(self):
         self.client = Client()
         # http://code.djangoproject.com/ticket/10899
-        settings.SESSION_ENGINE = 'django.contrib.sessions.backends.file'
+        settings.SESSION_ENGINE = "django.contrib.sessions.backends.file"
         engine = import_module(settings.SESSION_ENGINE)
         store = engine.SessionStore()
         store.save()
@@ -18,9 +18,9 @@ class TestTimeout(TestCase):
         self.client.cookies[settings.SESSION_COOKIE_NAME] = store.session_key
 
     def test_no_urn_no_refresh_headers(self):
-        response = self.client.get('/plea/case/')
+        response = self.client.get("/plea/case/")
 
-        self.assertEqual(response.has_header('Refresh'), False)
+        self.assertEqual(response.has_header("Refresh"), False)
 
     def test_no_session_in_request(self):
         request = {}
@@ -32,12 +32,13 @@ class TestTimeout(TestCase):
 
     def test_when_urn_has_refresh_headers(self):
         session = self.session
-        session["case"] = {"urn": "51/AA/00000/00"}
+        session["plea"] = {}
+        session["plea"]["case"] = {"urn": "51/AA/00000/00"}
         session.save()
 
-        response = self.client.get('/plea/case/')
+        response = self.client.get("/plea/case/")
 
         wait = str(getattr(settings, "SESSION_COOKIE_AGE", 3600));
 
-        self.assertEqual(response.has_header('Refresh'), True)
+        self.assertEqual(response.has_header("Refresh"), True)
         self.assertTrue("Refresh: " + wait + "; url=/session-timeout/" in response.serialize_headers())

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -40,7 +40,7 @@ class PleaOnlineForms(MultiStageForm):
         Check that the URN has not already been used.
         """
         try:
-            saved_urn = self.all_data['case']['urn']
+            saved_urn = self.all_data["case"]["urn"]
         except KeyError:
             saved_urn = None
 
@@ -53,7 +53,7 @@ class PleaOnlineForms(MultiStageForm):
 
     def render(self):
         if self._urn_invalid:
-            return redirect('urn_already_used')
+            return redirect("urn_already_used")
 
         return super(PleaOnlineForms, self).render()
 
@@ -64,12 +64,23 @@ class PleaOnlineViews(TemplateView):
     def dispatch(self, *args, **kwargs):
         return super(PleaOnlineViews, self).dispatch(*args, **kwargs)
 
+    def _get_storage(self, request):
+        if not request.session.get("plea"):
+            request.session["plea"] = {}
+
+        return request.session["plea"]
+
+    def _clear_storage(self, request):
+        del request.session["plea"]
+
     def get(self, request, stage=None):
+        storage = self._get_storage(request)
+        
         if not stage:
             stage = PleaOnlineForms.stage_classes[0].name
             return HttpResponseRedirect(reverse_lazy("plea_form_step", args=(stage,)))
 
-        form = PleaOnlineForms(stage, "plea_form_step", request.session)
+        form = PleaOnlineForms(stage, "plea_form_step", storage)
         redirect = form.load(RequestContext(request))
         if redirect:
             return redirect
@@ -77,19 +88,22 @@ class PleaOnlineViews(TemplateView):
         form.process_messages(request)
 
         if stage == "complete":
-            request.session.clear()
+            self._clear_storage(request)
 
         return form.render()
 
     @method_decorator(ratelimit(block=True, rate=settings.RATE_LIMIT))
     def post(self, request, stage):
+        storage = self._get_storage(request)
 
         nxt = request.GET.get("next", None)
 
-        form = PleaOnlineForms(stage, "plea_form_step", request.session)
+        form = PleaOnlineForms(stage, "plea_form_step", storage)
         form.save(request.POST, RequestContext(request), nxt)
         if not form._urn_invalid:
             form.process_messages(request)
+
+        request.session.modified = True
         return form.render()
 
 
@@ -98,9 +112,9 @@ class UrnAlreadyUsedView(TemplateView):
 
     def post(self, request):
 
-        request.session.flush()
+        del request.session["plea"]
 
-        return redirect('plea_form_step', stage="case")
+        return redirect("plea_form_step", stage="case")
 
 
 class CourtFinderView(FormView):

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -65,13 +65,13 @@ class PleaOnlineViews(TemplateView):
         return super(PleaOnlineViews, self).dispatch(*args, **kwargs)
 
     def _get_storage(self, request):
-        if not request.session.get("plea"):
-            request.session["plea"] = {}
+        if not request.session.get("plea_data"):
+            request.session["plea_data"] = {}
 
-        return request.session["plea"]
+        return request.session["plea_data"]
 
     def _clear_storage(self, request):
-        del request.session["plea"]
+        del request.session["plea_data"]
 
     def get(self, request, stage=None):
         storage = self._get_storage(request)
@@ -112,7 +112,7 @@ class UrnAlreadyUsedView(TemplateView):
 
     def post(self, request):
 
-        del request.session["plea"]
+        del request.session["plea_data"]
 
         return redirect("plea_form_step", stage="case")
 


### PR DESCRIPTION
This prevents the whole session having to be nuked on
completion, meaning things like language settings get
preserved: the feedback now appears in Welsh after
completing the journey in Welsh.

[MAPDEV406]