### PR TITLE
Redirect to Start screen after providing feedback at end of plea

### DIFF
--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -76,7 +76,7 @@ class PleaOnlineViews(TemplateView):
 
     def get(self, request, stage=None):
         storage = self._get_storage(request)
-        
+
         if not stage:
             stage = PleaOnlineForms.stage_classes[0].name
             return HttpResponseRedirect(reverse_lazy("plea_form_step", args=(stage,)))


### PR DESCRIPTION
The user was previously being redirected to the Case Details screen after completing a plea,
which made little sense.

Also added more specific debug message to the 404 that is thrown when
the stage is not set.