### PR TITLE
MAPDEV430 Update Confirmation screen

### DIFF
--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -175,10 +175,10 @@ class CourtEmailCount(models.Model):
         self.court = court
 
         try:
-            if isinstance(context["case"]["date_of_hearing"], dt.date):
-                date_part = context["case"]["date_of_hearing"]
+            if isinstance(context["case"]["contact_deadline"], dt.date):
+                date_part = context["case"]["contact_deadline"]
             else:
-                date_part = date_parse(context["case"]["date_of_hearing"])
+                date_part = date_parse(context["case"]["contact_deadline"])
 
             self.hearing_date = date_part
         except KeyError:

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -1,3 +1,4 @@
+from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.core.exceptions import MultipleObjectsReturned
 from django.forms.formsets import formset_factory
@@ -70,6 +71,13 @@ class CaseStage(FormStage):
 
         if "urn" in clean_data:
             clean_data["urn"] = slashify_urn(standardise_urn(clean_data["urn"]))
+
+        # Set the court contact deadline
+        if "date_of_hearing" in clean_data:
+            clean_data["contact_deadline"] = clean_data["date_of_hearing"]
+
+        if "posting_date" in clean_data:
+            clean_data["contact_deadline"] = clean_data["posting_date"] + relativedelta(days=+28)
 
         if "complete" in clean_data:
             if clean_data.get("plea_made_by", "Defendant") == "Defendant":

--- a/apps/plea/templates/complete.html
+++ b/apps/plea/templates/complete.html
@@ -4,7 +4,7 @@
 {% load date %}
 {% load testing %}
 
-{% block page_title %}{% blocktrans count charges=case.number_of_charges %}Your plea has been sent to the court{% plural %}Your pleas have been sent to the court{% endblocktrans %} - {{ block.super }}{% endblock %}
+{% block page_title %}{% blocktrans count charges=case.number_of_charges %}Your plea has been sent to the magistrate{% plural %}Your pleas have been sent to the magistrate{% endblocktrans %} - {{ block.super }}{% endblock %}
 
 {% block page_content %}
 
@@ -15,9 +15,9 @@
     <header class="success-header" role="alert">
         <h1 class="ticked">{% spaceless %}
             {% if case.plea_made_by == "Defendant" %}
-                {% blocktrans count charges=case.number_of_charges %}Your plea has been sent to the court{% plural %}Your pleas have been sent to the court{% endblocktrans %}
+                {% blocktrans count charges=case.number_of_charges %}Your plea has been sent to the magistrate{% plural %}Your pleas have been sent to the magistrate{% endblocktrans %}
             {% elif case.plea_made_by == "Company representative" %}
-                {% blocktrans count charges=case.number_of_charges %}Your company's plea has been sent to the court{% plural %}Your company's pleas have been sent to the court{% endblocktrans %}
+                {% blocktrans count charges=case.number_of_charges %}Your company's plea has been sent to the magistrate{% plural %}Your company's pleas have been sent to the magistrate{% endblocktrans %}
             {% endif %}
         {% endspaceless %}</h1>
     </header>
@@ -27,47 +27,43 @@
         <h2 class="heading-medium">{% blocktrans %}What happens next:{% endblocktrans %}</h2>
         <div class="panel-indent">
             <ul>
-            {% if plea_type == "guilty" or plea_type == "mixed" %}
-                {% if case.plea_made_by == "Defendant" %}
-                    <li>{% blocktrans count charges=case.number_of_charges %}we'll send you a letter with the court's decision within 3 working days after your hearing date{% plural %}we'll send you a letter with the court's decisions within 3 working days after your hearing date{% endblocktrans %}</li>
+            {% if case.plea_made_by == "Defendant" %}
+
+                {% if plea_type == "guilty" or plea_type == "mixed" %}
+                    <li>{% blocktrans count charges=case.number_of_charges %}we'll send you a letter with the magistrate's decision{% plural %}we'll send you a letter with the magistrate's decisions{% endblocktrans %}</li>
                     <li>{% blocktrans %}we'll tell you if you need to attend a trial and what evidence you may need to send to the court to support your case{% endblocktrans %}</li>
                 {% endif %}
 
-                {% if case.plea_made_by == "Company representative" %}
-                    <li>{% blocktrans count charges=case.number_of_charges %}we'll send a letter with the court's decision within 3 working days after the hearing date{% plural %}we'll send a letter with the court's decisions within 3 working days after the hearing date{% endblocktrans %}</li>
-                    <li>{% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}</li>
+                {% if plea_type == "not_guilty" %}
+                    <li>{% blocktrans %}we'll send you a letter with a hearing date for you to come to court for a trial{% endblocktrans %}</li>
                 {% endif %}
+
             {% endif %}
 
-            {% if plea_type == "not_guilty" %}
-                {% if case.plea_made_by == "Defendant" %}
-                    <li>{% blocktrans %}we'll send you a letter with a new hearing date for you to come to court for a trial{% endblocktrans %}</li>
+            {% if case.plea_made_by == "Company representative" %}
+
+                {% if plea_type == "guilty" or plea_type == "mixed" %}
+                    <li>{% blocktrans count charges=case.number_of_charges %}we'll send a letter with the magistrate's decision{% plural %}we'll send a letter with the magistrate's decisions{% endblocktrans %}</li>
+                    <li>{% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}</li>
                 {% endif %}
 
-                {% if case.plea_made_by == "Company representative" %}
-                    <li>{% blocktrans %}we'll send you a letter with a new hearing date for a company representative to come to court{% endblocktrans %}</li>
+                {% if plea_type == "not_guilty" %}
+                    <li>{% blocktrans %}we'll send you a letter with a hearing date for a company representative to attend a trial{% endblocktrans %}</li>
                 {% endif %}
+
             {% endif %}
 
                 <li>{% blocktrans %}you can <a href="javascript:window.print();">print a copy</a> of this plea confirmation for your records{% endblocktrans %}</li>
             </ul>
         </div>
 
-
-        <h2 class="heading-medium">{% blocktrans %}Do not:{% endblocktrans %}</h2>
-        <div class="panel-indent">
-            <ul>
-                <li>{% blocktrans %}come to court on the hearing date shown on page 1 of the requisition notice we sent to you{% endblocktrans %}</li>
-
-                {% if case.plea_made_by == "Defendant" %}
-                <li>{% blocktrans %}send your driving licence to the court, the DVLA will contact you if they need you to send it to them{% endblocktrans %}</li>
-                {% endif %}
-            </ul>
-        </div>
+        {% if case.plea_made_by == "Defendant" %}
+            <p class="lede">{% blocktrans %}Do not send your driving licence to the court. The DVLA will contact you if they need you to send it to them.{% endblocktrans %}</p>
+        {% endif %}
 
         <h2 class="heading-medium">{% blocktrans %}Need to change a plea?{% endblocktrans %}</h2>
 
-        <p>{% blocktrans with urn=case.urn|upper hearing_date=case.date_of_hearing|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ hearing_date }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with urn=case.urn|upper contact_deadline=case.contact_deadline|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ contact_deadline }}.{% endblocktrans %}</p>
 
         <p>{% blocktrans %}The contact details for the court are:{% endblocktrans %}</p>
 

--- a/apps/plea/templates/emails/user_plea_confirmation.html
+++ b/apps/plea/templates/emails/user_plea_confirmation.html
@@ -6,6 +6,12 @@
 
 {% block subject %}{% blocktrans %}Online plea submission confirmation{% endblocktrans %}{% endblock subject %}
 
+{% block extra_css %}
+    p.donot {
+        margin-top: 36px;
+    }
+{% endblock extra_css %}
+
 {% block content %}
 
     {% if plea_type == "guilty" %}{% add_test_tag "<<GUILTY>>" %}{% endif %}
@@ -13,50 +19,43 @@
     {% if plea_type == "mixed" %}{% add_test_tag "<<MIXED>>" %}{% endif %}
 
 
-    <h1>{% spaceless %}
-        {% if plea_made_by == "Defendant" %}
-            {% blocktrans count charges=number_of_charges %}Your plea has been sent to the court{% plural %}Your pleas have been sent to the court{% endblocktrans %}
-        {% elif plea_made_by == "Company representative" %}
-            {% blocktrans count charges=number_of_charges %}Your company's plea has been sent to the court{% plural %}Your company's pleas have been sent to the court{% endblocktrans %}
-        {% endif %}
-    {% endspaceless %}</h1>
+    <h1>{% blocktrans count charges=number_of_charges %}Your online plea has been submitted{% plural %}Your online pleas have been submitted{% endblocktrans %}</h1>
 
     <h2>{% blocktrans %}What happens next:{% endblocktrans %}</h2>
 
     <ul>
-    {% if plea_type == "guilty" or plea_type == "mixed" %}
-        {% if plea_made_by == "Defendant" %}
-            <li>{% blocktrans count charges=number_of_charges %}we'll send you a letter with the court's decision within 3 working days after your hearing date{% plural %}we'll send you a letter with the court's decisions within 3 working days after your hearing date{% endblocktrans %}</li>
+    {% if plea_made_by == "Defendant" %}
+
+        {% if plea_type == "guilty" or plea_type == "mixed" %}
+            <li>{% blocktrans count charges=number_of_charges %}we'll send you a letter with the magistrate's decision{% plural %}we'll send you a letter with the magistrate's decisions{% endblocktrans %}</li>
             <li>{% blocktrans %}we'll tell you if you need to attend a trial and what evidence you may need to send to the court to support your case{% endblocktrans %}</li>
         {% endif %}
 
-        {% if plea_made_by == "Company representative" %}
-            <li>{% blocktrans count charges=number_of_charges %}we'll send a letter with the court's decision within 3 working days after the hearing date{% plural %}we'll send a letter with the court's decisions within 3 working days after the hearing date{% endblocktrans %}</li>
-            <li>{% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}</li>
+        {% if plea_type == "not_guilty" %}
+            <li>{% blocktrans %}we'll send you a letter with a hearing date for you to come to court for a trial{% endblocktrans %}</li>
         {% endif %}
+
     {% endif %}
 
-    {% if plea_type == "not_guilty" %}
-        {% if plea_made_by == "Defendant" %}
-            <li>{% blocktrans %}we'll send you a letter with a new hearing date for you to come to court for a trial{% endblocktrans %}</li>
+    {% if plea_made_by == "Company representative" %}
+
+        {% if plea_type == "guilty" or plea_type == "mixed" %}
+            <li>{% blocktrans count charges=number_of_charges %}we'll send a letter with the magistrate's decision{% plural %}we'll send a letter with the magistrate's decisions{% endblocktrans %}</li>
+            <li>{% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}</li>
         {% endif %}
 
-        {% if plea_made_by == "Company representative" %}
-            <li>{% blocktrans %}we'll send you a letter with a new hearing date for a company representative to come to court{% endblocktrans %}</li>
+        {% if plea_type == "not_guilty" %}
+            <li>{% blocktrans %}we'll send you a letter with a hearing date for a company representative to attend a trial{% endblocktrans %}</li>
         {% endif %}
+
     {% endif %}
 
         <li>{% blocktrans %}you can print a copy of this plea confirmation for your records{% endblocktrans %}</li>
     </ul>
 
-    <h2>{% blocktrans %}Do not:{% endblocktrans %}</h2>
-    <ul>
-        <li>{% blocktrans %}come to court on the hearing date shown on page 1 of the requisition notice we sent to you{% endblocktrans %}</li>
-
-        {% if plea_made_by == "Defendant" %}
-        <li>{% blocktrans %}send your driving licence to the court, the DVLA will contact you if they need you to send it to them{% endblocktrans %}</li>
-        {% endif %}
-    </ul>
+    {% if plea_made_by == "Defendant" %}
+    <p class="donot">{% blocktrans %}Do not send your driving licence to the court. The DVLA will contact you if they need you to send it to them.{% endblocktrans %}</p>
+    {% endif %}
 
     <h2>{% blocktrans %}Need to change a plea?{% endblocktrans %}</h2>
 
@@ -64,11 +63,11 @@
 
     <p>{% blocktrans %}The contact details for the court are:{% endblocktrans %}</p>
 
-    <p><strong>{% blocktrans %}By Post:{% endblocktrans %}</strong><br>
-        {{ court_address|linebreaksbr }}</p>
+    <h3>{% blocktrans %}By post:{% endblocktrans %}</h3>
+    <p>{{ court_address|linebreaksbr }}</p>
 
-    <p><strong>{% blocktrans %}By email:{% endblocktrans %}</strong><br>
-        <a href="mailto:{{ court_email }}">{{ court_email }}</a></p>
+    <h3>{% blocktrans %}By email:{% endblocktrans %}</h3>
+    <p><a href="mailto:{{ court_email }}">{{ court_email }}</a></p>
 
     <h2>{% blocktrans %}We're constantly working to improve this service.{% endblocktrans %}</h2>
 

--- a/apps/plea/templates/emails/user_plea_confirmation.html
+++ b/apps/plea/templates/emails/user_plea_confirmation.html
@@ -60,7 +60,7 @@
 
     <h2>{% blocktrans %}Need to change a plea?{% endblocktrans %}</h2>
 
-    <p>{% blocktrans with urn=urn|upper hearing_date=date_of_hearing|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ hearing_date }}.{% endblocktrans %}</p>
+    <p>{% blocktrans with urn=urn|upper contact_deadline=contact_deadline|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ contact_deadline }}.{% endblocktrans %}</p>
 
     <p>{% blocktrans %}The contact details for the court are:{% endblocktrans %}</p>
 

--- a/apps/plea/templates/emails/user_plea_confirmation.txt
+++ b/apps/plea/templates/emails/user_plea_confirmation.txt
@@ -39,7 +39,7 @@ https://www.makeaplea.justice.gov.uk/feedback/
 {% blocktrans %}If you're unsure an email is from the Ministry of Justice:{% endblocktrans %}
 
 - {% blocktrans %}do not reply to it or click any links{% endblocktrans %}
-- {% blocktrans %}forward it to{% endblocktrans %} feedback@makeaplea.gov.uk
+- {% blocktrans %}forward it to{% endblocktrans %} makeaplea@justice.gov.uk
 
 {% blocktrans %}Terms and Conditions and Privacy Policy:{% endblocktrans %}
 https://www.makeaplea.justice.gov.uk/terms-and-conditions-and-privacy-policy

--- a/apps/plea/templates/emails/user_plea_confirmation.txt
+++ b/apps/plea/templates/emails/user_plea_confirmation.txt
@@ -20,7 +20,7 @@
 ------
 
 {% blocktrans %}Need to change a plea?{% endblocktrans %}
-{% blocktrans with urn=urn|upper hearing_date=date_of_hearing|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ hearing_date }}.{% endblocktrans %}
+{% blocktrans with urn=urn|upper contact_deadline=contact_deadline|parse_date|date:"d/m/Y" %}Contact the court by post or email quoting your URN {{ urn }} to arrive before {{ contact_deadline }}.{% endblocktrans %}
 
 {% blocktrans %}The contact details for the court are:{% endblocktrans %}
 

--- a/apps/plea/templates/emails/user_plea_confirmation.txt
+++ b/apps/plea/templates/emails/user_plea_confirmation.txt
@@ -1,21 +1,18 @@
 {% load testing date i18n %}{% blocktrans %}GOV.UK - Online plea submission confirmation{% endblocktrans %}
 
-{% if plea_made_by == "Defendant" %}{% blocktrans count charges=number_of_charges %}Your plea has been sent to the court{% plural %}Your pleas have been sent to the court{% endblocktrans %}{% elif plea_made_by == "Company representative" %}{% blocktrans count charges=number_of_charges %}Your company's plea has been sent to the court{% plural %}Your company's pleas have been sent to the court{% endblocktrans %}{% endif %}
+{% blocktrans count charges=number_of_charges %}Your online plea has been submitted{% plural %}Your online pleas have been submitted{% endblocktrans %}
 
 ------
-
-{% blocktrans %}What happens next:{% endblocktrans %}{% if plea_type == "guilty" or plea_type == "mixed" %}{% if plea_made_by == "Defendant" %}
-- {% blocktrans count charges=number_of_charges %}we'll send you a letter with the court's decision within 3 working days after your hearing date{% plural %}we'll send you a letter with the court's decisions within 3 working days after your hearing date{% endblocktrans %}
-- {% blocktrans %}we'll tell you if you need to attend a trial and what evidence you may need to send to the court to support your case{% endblocktrans %}{% endif %}{% if plea_made_by == "Company representative" %}
-- {% blocktrans count charges=number_of_charges %}we'll send a letter with the court's decision within 3 working days after the hearing date{% plural %}we'll send a letter with the court's decisions within 3 working days after the hearing date{% endblocktrans %}
-- {% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}{% endif %}{% endif %}{% if plea_type == "not_guilty" %}{% if plea_made_by == "Defendant" %}
-- {% blocktrans %}we'll send you a letter with a new hearing date for you to come to court for a trial{% endblocktrans %}{% endif %}{% if plea_made_by == "Company representative" %}
-- {% blocktrans %}we'll send you a letter with a new hearing date for a company representative to come to court{% endblocktrans %}{% endif %}{% endif %}
+{% if plea_made_by == "Defendant" %}{% if plea_type == "guilty" or plea_type == "mixed" %}
+- {% blocktrans count charges=number_of_charges %}we'll send you a letter with the magistrate's decision{% plural %}we'll send you a letter with the magistrate's decisions{% endblocktrans %}
+- {% blocktrans %}we'll tell you if you need to attend a trial and what evidence you may need to send to the court to support your case{% endblocktrans %}{% endif %}{% if plea_type == "not_guilty" %}
+- {% blocktrans %}we'll send you a letter with a hearing date for you to come to court for a trial{% endblocktrans %}{% endif %}{% endif %}{% if plea_made_by == "Company representative" %}{% if plea_type == "guilty" or plea_type == "mixed" %}
+- {% blocktrans count charges=number_of_charges %}we'll send a letter with the magistrate's decision{% plural %}we'll send a letter with the magistrate's decisions{% endblocktrans %}
+- {% blocktrans %}we'll tell you if a company representative needs to attend a trial and what evidence you may need to send to the court to support the case{% endblocktrans %}{% endif %}{% if plea_type == "not_guilty" %}
+- {% blocktrans %}we'll send you a letter with a hearing date for a company representative to attend a trial{% endblocktrans %}{% endif %}{% endif %}
 - {% blocktrans %}you can print a copy of this plea confirmation for your records{% endblocktrans %}
 
-{% blocktrans %}Do not:{% endblocktrans %}
-- {% blocktrans %}come to court on the hearing date shown on page 1 of the requisition notice we sent to you{% endblocktrans %}{% if plea_made_by == "Defendant" %}
-- {% blocktrans %}send your driving licence to the court, the DVLA will contact you if they need you to send it to them{% endblocktrans %}{% endif %}
+{% if plea_made_by == "Defendant" %}{% blocktrans %}Do not send your driving licence to the court. The DVLA will contact you if they need you to send it to them.{% endblocktrans %}{% endif %}
 
 ------
 
@@ -24,7 +21,7 @@
 
 {% blocktrans %}The contact details for the court are:{% endblocktrans %}
 
-{% blocktrans %}By Post:{% endblocktrans %}
+{% blocktrans %}By post:{% endblocktrans %}
 {{ court_address }}
 
 {% blocktrans %}By email:{% endblocktrans %}

--- a/apps/plea/tests/test_audit.py
+++ b/apps/plea/tests/test_audit.py
@@ -35,7 +35,7 @@ class CaseCreationTests(TestCase):
             'notice_type': {u'sjp': False},
             'case': {u'urn': u'06/aa/0000000/00',
                       u'date_of_hearing': datetime.date(2015, 1, 1),
-                      u'time_of_hearing': datetime.time(9, 15),
+                      u'contact_deadline': datetime.date(2015, 1, 1),
                       u'number_of_charges': 2,
                       u'plea_made_by': "Defendant"},
             'your_details': {

--- a/apps/plea/tests/test_email_generation.py
+++ b/apps/plea/tests/test_email_generation.py
@@ -31,6 +31,7 @@ class EmailGenerationTests(TestCase):
         self.test_data_defendant = {"notice_type": {"sjp": False},
                                     "case": {"urn": "06xcvx89",
                                              "date_of_hearing": "2014-06-30",
+                                             "contact_deadline": "2014-06-30",
                                              "number_of_charges": 2,
                                              "plea_made_by": "Defendant"},
                                     "your_details": {"updated_address": "Some place",
@@ -47,6 +48,7 @@ class EmailGenerationTests(TestCase):
         self.test_data_company = {"notice_type": {"sjp": False},
                                   "case": {"urn": "06xcvx89",
                                            "date_of_hearing": "2014-06-30",
+                                           "contact_deadline": "2014-06-30",
                                            "number_of_charges": 2,
                                            "plea_made_by": "Company representative"},
                                   "your_details": {"complete": True,
@@ -82,6 +84,24 @@ class EmailGenerationTests(TestCase):
         send_plea_email(self.test_data_defendant)
 
         self.assertEqual(len(mail.outbox), 3)
+
+    def test_plea_email_adds_to_court_stats(self):
+        send_plea_email(self.test_data_defendant)
+
+        court_stats_count = CourtEmailCount.objects.count()
+
+        self.assertEqual(court_stats_count, 1)
+
+    def test_sjp_plea_email_adds_to_court_stats(self):
+        self.test_data_defendant["notice_type"]["sjp"] = True
+        self.test_data_defendant["case"]["posting_date"] = "2014-06-30"
+        del self.test_data_defendant["case"]["date_of_hearing"]
+
+        send_plea_email(self.test_data_defendant)
+
+        court_stats_count = CourtEmailCount.objects.count()
+
+        self.assertEqual(court_stats_count, 1)
 
     def test_plea_email_body_contains_plea_and_count_ids(self):
         send_plea_email(self.test_data_defendant)

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -178,8 +178,7 @@ class EmailTemplateTests(TestCase):
         send_plea_email(context_data)
 
         self.assertEqual(len(mail.outbox), 3)
-        self.assertEqual(mail.outbox[0].subject, "ONLINE PLEA: 06/AA/00000/00 <SJP> PUBLIC Joe"
-            .format(self.hearing_date.strftime("%Y-%m-%d")))
+        self.assertEqual(mail.outbox[0].subject, "ONLINE PLEA: 06/AA/00000/00 <SJP> PUBLIC Joe")
 
     def test_notice_type_not_sjp_output(self):
         context_data = self.get_context_data()

--- a/apps/plea/tests/test_models.py
+++ b/apps/plea/tests/test_models.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-import datetime as dt 
+import datetime as dt
 
 from django.test import TestCase
 
@@ -32,7 +32,8 @@ class CourtEmailCountModelTestCase(TestCase):
                 "registration_number": "xxx"
             },
             "case": {
-                "date_of_hearing": "2014-09-22"
+                "date_of_hearing": "2014-09-22",
+                "contact_deadline": "2014-09-22"
             }
         }
         emailcount = CourtEmailCount()
@@ -103,7 +104,7 @@ class CourtEmailCountModelTestCase(TestCase):
             },
             "case": {
                 "date_of_hearing": "2014-09-22",
-                "time_of_hearing": "09:15:00"
+                "contact_deadline": "2014-09-22",
             },
         }
 

--- a/conf/locale/cy/LC_MESSAGES/django.po
+++ b/conf/locale/cy/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Make a Plea\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-08 15:43+0100\n"
+"POT-Creation-Date: 2015-10-12 12:20+0100\n"
 "PO-Revision-Date: 2015-09-23 14:36+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi."
 "gov.uk>\n"
@@ -88,7 +88,7 @@ msgstr "Os hoffech inni ddod yn ôl atoch, rhowch eich cyfeiriad e-bost isod:"
 msgid "Your feedback has been submitted"
 msgstr "Mae eich adborth wedi cael ei gyflwyno"
 
-#: apps/feedback/stages.py:37 apps/plea/stages.py:364
+#: apps/feedback/stages.py:37 apps/plea/stages.py:372
 msgid "Submission Error"
 msgstr "Gwall wrth gyflwyno"
 
@@ -224,7 +224,7 @@ msgstr "Dieuog"
 msgid "Change this plea"
 msgstr "Newid y ple hwn"
 
-#: apps/plea/email.py:129
+#: apps/plea/email.py:121
 #: apps/plea/templates/emails/user_plea_confirmation.html:7
 msgid "Online plea submission confirmation"
 msgstr "Cadarnhad o gofnodi ple ar-lein"
@@ -1046,7 +1046,7 @@ msgstr "Os oes, dywedwch wrthym pa iaith (gan gynnwys iaith arwyddion):"
 msgid "On page 1, usually at the top."
 msgstr "Ar dudalen 1, fel arfer ar y brig."
 
-#: apps/plea/stages.py:365
+#: apps/plea/stages.py:373
 msgid ""
 "There seems to have been a problem submitting your plea. Please try again."
 msgstr ""
@@ -1167,40 +1167,44 @@ msgstr ""
 "Ar sail yr amcanestyniadau o'r 12 mis cyntaf o fasnachu, dywedwch wrthym:"
 
 #: apps/plea/templates/complete.html:7 apps/plea/templates/complete.html:18
-#: apps/plea/templates/emails/user_plea_confirmation.html:18
-#: apps/plea/templates/emails/user_plea_confirmation.txt:3
-msgid "Your plea has been sent to the court"
-msgid_plural "Your pleas have been sent to the court"
+#, fuzzy
+#| msgid "Your plea has been sent to the court"
+#| msgid_plural "Your pleas have been sent to the court"
+msgid "Your plea has been sent to the magistrate"
+msgid_plural "Your pleas have been sent to the magistrate"
 msgstr[0] "Mae eich ple wedi cael ei anfon i'r llys"
 msgstr[1] "Mae eich pledion wedi cael eu hanfon i'r llys"
 msgstr[2] "Mae eich pledion wedi cael eu hanfon i'r llys"
 msgstr[3] "Mae eich pledion wedi cael eu hanfon i'r llys"
 
 #: apps/plea/templates/complete.html:20
-#: apps/plea/templates/emails/user_plea_confirmation.html:20
-#: apps/plea/templates/emails/user_plea_confirmation.txt:3
-msgid "Your company's plea has been sent to the court"
-msgid_plural "Your company's pleas have been sent to the court"
+#, fuzzy
+#| msgid "Your company's plea has been sent to the court"
+#| msgid_plural "Your company's pleas have been sent to the court"
+msgid "Your company's plea has been sent to the magistrate"
+msgid_plural "Your company's pleas have been sent to the magistrate"
 msgstr[0] "Mae ple eich cwmni wedi cael ei anfon i'r llys"
 msgstr[1] "Mae ple eich cwmni wedi cael ei anfon i'r llys"
 msgstr[2] "Mae ple eich cwmni wedi cael ei anfon i'r llys"
 msgstr[3] "Mae pledion eich cwmni wedi cael eu hanfon i'r llys"
 
 #: apps/plea/templates/complete.html:27
-#: apps/plea/templates/emails/user_plea_confirmation.html:24
-#: apps/plea/templates/emails/user_plea_confirmation.txt:7
+#: apps/plea/templates/emails/user_plea_confirmation.html:18
 msgid "What happens next:"
 msgstr "Beth fydd yn digwydd nesaf:"
 
-#: apps/plea/templates/complete.html:32
-#: apps/plea/templates/emails/user_plea_confirmation.html:29
-#: apps/plea/templates/emails/user_plea_confirmation.txt:8
-msgid ""
-"we'll send you a letter with the court's decision within 3 working days "
-"after your hearing date"
-msgid_plural ""
-"we'll send you a letter with the court's decisions within 3 working days "
-"after your hearing date"
+#: apps/plea/templates/complete.html:33
+#: apps/plea/templates/emails/user_plea_confirmation.html:24
+#: apps/plea/templates/emails/user_plea_confirmation.txt:7
+#, fuzzy
+#| msgid ""
+#| "we'll send you a letter with the court's decision within 3 working days "
+#| "after your hearing date"
+#| msgid_plural ""
+#| "we'll send you a letter with the court's decisions within 3 working days "
+#| "after your hearing date"
+msgid "we'll send you a letter with the magistrate's decision"
+msgid_plural "we'll send you a letter with the magistrate's decisions"
 msgstr[0] ""
 "byddwn yn anfon llythyr atoch yn dweud beth yw penderfyniad y llys cyn pen 3 "
 "diwrnod gwaith ar ôl dyddiad eich gwrandawiad"
@@ -1214,9 +1218,9 @@ msgstr[3] ""
 "byddwn yn anfon llythyr atoch yn dweud beth yw penderfyniadau'r llys cyn pen "
 "3 diwrnod gwaith ar ôl dyddiad eich gwrandawiad"
 
-#: apps/plea/templates/complete.html:33
-#: apps/plea/templates/emails/user_plea_confirmation.html:30
-#: apps/plea/templates/emails/user_plea_confirmation.txt:9
+#: apps/plea/templates/complete.html:34
+#: apps/plea/templates/emails/user_plea_confirmation.html:25
+#: apps/plea/templates/emails/user_plea_confirmation.txt:8
 msgid ""
 "we'll tell you if you need to attend a trial and what evidence you may need "
 "to send to the court to support your case"
@@ -1225,15 +1229,32 @@ msgstr ""
 "pha dystiolaeth y mae’n bosib y bydd angen i chi ei hanfon i'r llys i "
 "gefnogi eich achos."
 
-#: apps/plea/templates/complete.html:37
-#: apps/plea/templates/emails/user_plea_confirmation.html:34
-#: apps/plea/templates/emails/user_plea_confirmation.txt:10
+#: apps/plea/templates/complete.html:38
+#: apps/plea/templates/emails/user_plea_confirmation.html:29
+#: apps/plea/templates/emails/user_plea_confirmation.txt:9
+#, fuzzy
+#| msgid ""
+#| "we'll send you a letter with a new hearing date for you to come to court "
+#| "for a trial"
 msgid ""
-"we'll send a letter with the court's decision within 3 working days after "
-"the hearing date"
-msgid_plural ""
-"we'll send a letter with the court's decisions within 3 working days after "
-"the hearing date"
+"we'll send you a letter with a hearing date for you to come to court for a "
+"trial"
+msgstr ""
+"byddwn yn anfon llythyr atoch yn rhoi dyddiad gwrandawiad newydd i chi ddod "
+"i'r llys ar gyfer treial"
+
+#: apps/plea/templates/complete.html:46
+#: apps/plea/templates/emails/user_plea_confirmation.html:37
+#: apps/plea/templates/emails/user_plea_confirmation.txt:10
+#, fuzzy
+#| msgid ""
+#| "we'll send a letter with the court's decision within 3 working days after "
+#| "the hearing date"
+#| msgid_plural ""
+#| "we'll send a letter with the court's decisions within 3 working days "
+#| "after the hearing date"
+msgid "we'll send a letter with the magistrate's decision"
+msgid_plural "we'll send a letter with the magistrate's decisions"
 msgstr[0] ""
 "byddwn yn anfon llythyr yn dweud beth yw penderfyniad y llys cyn pen 3 "
 "diwrnod gwaith ar ôl dyddiad y gwrandawiad"
@@ -1247,8 +1268,8 @@ msgstr[3] ""
 "byddwn yn anfon llythyr yn dweud beth yw penderfyniadau'r llys cyn pen 3 "
 "diwrnod gwaith ar ôl dyddiad y gwrandawiad"
 
-#: apps/plea/templates/complete.html:38
-#: apps/plea/templates/emails/user_plea_confirmation.html:35
+#: apps/plea/templates/complete.html:47
+#: apps/plea/templates/emails/user_plea_confirmation.html:38
 #: apps/plea/templates/emails/user_plea_confirmation.txt:11
 msgid ""
 "we'll tell you if a company representative needs to attend a trial and what "
@@ -1258,27 +1279,21 @@ msgstr ""
 "bresennol mewn treial, a pha dystiolaeth y mae’n bosib y bydd angen i chi ei "
 "hanfon i'r llys i gefnogi'r achos."
 
-#: apps/plea/templates/complete.html:44
-#: apps/plea/templates/emails/user_plea_confirmation.html:41
+#: apps/plea/templates/complete.html:51
+#: apps/plea/templates/emails/user_plea_confirmation.html:42
 #: apps/plea/templates/emails/user_plea_confirmation.txt:12
+#, fuzzy
+#| msgid ""
+#| "we'll send you a letter with a new hearing date for a company "
+#| "representative to come to court"
 msgid ""
-"we'll send you a letter with a new hearing date for you to come to court for "
-"a trial"
-msgstr ""
-"byddwn yn anfon llythyr atoch yn rhoi dyddiad gwrandawiad newydd i chi ddod "
-"i'r llys ar gyfer treial"
-
-#: apps/plea/templates/complete.html:48
-#: apps/plea/templates/emails/user_plea_confirmation.html:45
-#: apps/plea/templates/emails/user_plea_confirmation.txt:13
-msgid ""
-"we'll send you a letter with a new hearing date for a company representative "
-"to come to court"
+"we'll send you a letter with a hearing date for a company representative to "
+"attend a trial"
 msgstr ""
 "byddwn yn anfon llythyr atoch yn rhoi dyddiad gwrandawiad newydd i "
 "gynrychiolydd o'r cwmni ddod i'r llys"
 
-#: apps/plea/templates/complete.html:52
+#: apps/plea/templates/complete.html:56
 msgid ""
 "you can <a href=\"javascript:window.print();\">print a copy</a> of this plea "
 "confirmation for your records"
@@ -1286,68 +1301,61 @@ msgstr ""
 "gallwch <a href=\"javascript:window.print();\">argraffu copi</a> o'r "
 "cadarnhad hwn o'ch ple ar gyfer eich cofnodion"
 
-#: apps/plea/templates/complete.html:57
-#: apps/plea/templates/emails/user_plea_confirmation.html:52
-#: apps/plea/templates/emails/user_plea_confirmation.txt:16
-msgid "Do not:"
-msgstr "Peidiwch â gwneud y canlynol:"
-
-#: apps/plea/templates/complete.html:60
-#: apps/plea/templates/emails/user_plea_confirmation.html:54
-#: apps/plea/templates/emails/user_plea_confirmation.txt:17
+#: apps/plea/templates/complete.html:61
+#: apps/plea/templates/emails/user_plea_confirmation.html:51
+#: apps/plea/templates/emails/user_plea_confirmation.txt:15
+#, fuzzy
+#| msgid ""
+#| "send your driving licence to the court, the DVLA will contact you if they "
+#| "need you to send it to them"
 msgid ""
-"come to court on the hearing date shown on page 1 of the requisition notice "
-"we sent to you"
-msgstr ""
-"dod i'r llys ar y dyddiad gwrandawiad a ddangosir ar dudalen 1 yr hysbysiad "
-"gwysio a anfonwyd atoch"
-
-#: apps/plea/templates/complete.html:63
-#: apps/plea/templates/emails/user_plea_confirmation.html:57
-#: apps/plea/templates/emails/user_plea_confirmation.txt:18
-msgid ""
-"send your driving licence to the court, the DVLA will contact you if they "
-"need you to send it to them"
+"Do not send your driving licence to the court. The DVLA will contact you if "
+"they need you to send it to them."
 msgstr ""
 "anfon eich trwydded yrru i'r llys. Bydd y DVLA yn cysylltu â chi os oes "
 "angen i chi ei hanfon atynt.  "
 
-#: apps/plea/templates/complete.html:68
-#: apps/plea/templates/emails/user_plea_confirmation.html:61
-#: apps/plea/templates/emails/user_plea_confirmation.txt:22
+#: apps/plea/templates/complete.html:64
+#: apps/plea/templates/emails/user_plea_confirmation.html:54
+#: apps/plea/templates/emails/user_plea_confirmation.txt:19
 msgid "Need to change a plea?"
 msgstr "Angen newid ple?"
 
-#: apps/plea/templates/complete.html:70
-#: apps/plea/templates/emails/user_plea_confirmation.html:63
-#: apps/plea/templates/emails/user_plea_confirmation.txt:23
-#, python-format
+#: apps/plea/templates/complete.html:66
+#: apps/plea/templates/emails/user_plea_confirmation.html:56
+#: apps/plea/templates/emails/user_plea_confirmation.txt:20
+#, fuzzy, python-format
+#| msgid ""
+#| "Contact the court by post or email quoting your URN %(urn)s to arrive "
+#| "before %(hearing_date)s."
 msgid ""
 "Contact the court by post or email quoting your URN %(urn)s to arrive before "
-"%(hearing_date)s."
+"%(contact_deadline)s."
 msgstr ""
 "Cysylltwch â'r llys drwy'r post neu e-bost gan ddyfynnu eich cyfeirnod "
 "unigryw %(urn)s fel bod y neges yn cyrraedd cyn %(hearing_date)s."
 
-#: apps/plea/templates/complete.html:72
-#: apps/plea/templates/emails/user_plea_confirmation.html:65
-#: apps/plea/templates/emails/user_plea_confirmation.txt:25
+#: apps/plea/templates/complete.html:68
+#: apps/plea/templates/emails/user_plea_confirmation.html:58
+#: apps/plea/templates/emails/user_plea_confirmation.txt:22
 msgid "The contact details for the court are:"
 msgstr "Y manylion cyswllt ar gyfer eich llys yw:"
 
-#: apps/plea/templates/complete.html:74
+#: apps/plea/templates/complete.html:70
 #: apps/plea/templates/court_finder.html:21
+#: apps/plea/templates/emails/user_plea_confirmation.html:60
+#: apps/plea/templates/emails/user_plea_confirmation.txt:24
 msgid "By post:"
 msgstr "Drwy’r post:"
 
-#: apps/plea/templates/complete.html:78
+#: apps/plea/templates/complete.html:74
 #: apps/plea/templates/court_finder.html:26
-#: apps/plea/templates/emails/user_plea_confirmation.html:70
-#: apps/plea/templates/emails/user_plea_confirmation.txt:30
+#: apps/plea/templates/emails/user_plea_confirmation.html:63
+#: apps/plea/templates/emails/user_plea_confirmation.txt:27
 msgid "By email:"
 msgstr "Drwy e-bost:"
 
-#: apps/plea/templates/complete.html:82
+#: apps/plea/templates/complete.html:78
 msgid "Finish"
 msgstr "Gorffen"
 
@@ -1453,23 +1461,29 @@ msgstr "Eich treuliau"
 msgid "Company financial details"
 msgstr "Manylion ariannol y cwmni"
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:49
-#: apps/plea/templates/emails/user_plea_confirmation.txt:14
+#: apps/plea/templates/emails/user_plea_confirmation.html:16
+#: apps/plea/templates/emails/user_plea_confirmation.txt:3
+#, fuzzy
+#| msgid "Your feedback has been submitted"
+msgid "Your online plea has been submitted"
+msgid_plural "Your online pleas have been submitted"
+msgstr[0] "Mae eich adborth wedi cael ei gyflwyno"
+msgstr[1] "Mae eich adborth wedi cael ei gyflwyno"
+msgstr[2] "Mae eich adborth wedi cael ei gyflwyno"
+msgstr[3] "Mae eich adborth wedi cael ei gyflwyno"
+
+#: apps/plea/templates/emails/user_plea_confirmation.html:47
+#: apps/plea/templates/emails/user_plea_confirmation.txt:13
 msgid "you can print a copy of this plea confirmation for your records"
 msgstr ""
 "gallwch argraffu copi o'r cadarnhad hwn o'ch ple ar gyfer eich cofnodion"
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:67
-#: apps/plea/templates/emails/user_plea_confirmation.txt:27
-msgid "By Post:"
-msgstr "Drwy’r Post:"
-
-#: apps/plea/templates/emails/user_plea_confirmation.html:73
-#: apps/plea/templates/emails/user_plea_confirmation.txt:35
+#: apps/plea/templates/emails/user_plea_confirmation.html:66
+#: apps/plea/templates/emails/user_plea_confirmation.txt:32
 msgid "We're constantly working to improve this service."
 msgstr "Rydym yn gweithio'n barhaus i wella'r gwasanaeth hwn."
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:75
+#: apps/plea/templates/emails/user_plea_confirmation.html:68
 msgid ""
 "Please give us <a href=\"/feedback/\">feedback</a> so we can make it better."
 msgstr "Rhowch <a href=\"/feedback/\">adborth</a> i ni fel y gallwn ei wella."
@@ -1478,28 +1492,28 @@ msgstr "Rhowch <a href=\"/feedback/\">adborth</a> i ni fel y gallwn ei wella."
 msgid "GOV.UK - Online plea submission confirmation"
 msgstr "GOV.UK - Cadarnhad o gofnodi ple ar-lein"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:37
+#: apps/plea/templates/emails/user_plea_confirmation.txt:34
 msgid "Please give us feedback so we can make it better:"
 msgstr "Gofynnwn yn garedig ichi roi adborth inni fel y gallwn ei wella:"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:42
-#: make_a_plea/templates/base_user_email.html:196
+#: apps/plea/templates/emails/user_plea_confirmation.txt:39
+#: make_a_plea/templates/base_user_email.html:192
 msgid "If you're unsure an email is from the Ministry of Justice:"
 msgstr ""
 "Os nad ydych yn siŵr fod neges e-bost wedi cael ei hanfon gan y Weinyddiaeth "
 "Cyfiawnder:"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:44
-#: make_a_plea/templates/base_user_email.html:199
+#: apps/plea/templates/emails/user_plea_confirmation.txt:41
+#: make_a_plea/templates/base_user_email.html:195
 msgid "do not reply to it or click any links"
 msgstr "peidiwch ag ateb y neges na chlicio ar unrhyw ddolenni"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:45
-#: make_a_plea/templates/base_user_email.html:200
+#: apps/plea/templates/emails/user_plea_confirmation.txt:42
+#: make_a_plea/templates/base_user_email.html:196
 msgid "forward it to"
 msgstr "anfonwch y neges ymlaen i"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:47
+#: apps/plea/templates/emails/user_plea_confirmation.txt:44
 msgid "Terms and Conditions and Privacy Policy:"
 msgstr "Telerau ac Amodau a Pholisi Preifatrwydd:"
 
@@ -2144,7 +2158,7 @@ msgstr "Cymraeg"
 msgid "You have entered some information"
 msgstr "Rydych wedi rhoi rhywfaint o wybodaeth"
 
-#: make_a_plea/templates/base_user_email.html:203
+#: make_a_plea/templates/base_user_email.html:199
 msgid "Terms and Conditions and privacy policy"
 msgstr "Telerau ac Amodau a pholisi preifatrwydd"
 
@@ -2230,3 +2244,16 @@ msgstr "Cwestiynau am eich pledion?"
 #: make_a_plea/templates/start.html:54
 msgid "Need help using this service?"
 msgstr "Angen help i ddefnyddio'r gwasanaeth hwn?"
+
+#~ msgid "By Post:"
+#~ msgstr "Drwy’r Post:"
+
+#~ msgid "Do not:"
+#~ msgstr "Peidiwch â gwneud y canlynol:"
+
+#~ msgid ""
+#~ "come to court on the hearing date shown on page 1 of the requisition "
+#~ "notice we sent to you"
+#~ msgstr ""
+#~ "dod i'r llys ar y dyddiad gwrandawiad a ddangosir ar dudalen 1 yr "
+#~ "hysbysiad gwysio a anfonwyd atoch"

--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-08 15:43+0100\n"
+"POT-Creation-Date: 2015-10-12 12:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Your feedback has been submitted"
 msgstr ""
 
-#: apps/feedback/stages.py:37 apps/plea/stages.py:364
+#: apps/feedback/stages.py:37 apps/plea/stages.py:372
 msgid "Submission Error"
 msgstr ""
 
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Change this plea"
 msgstr ""
 
-#: apps/plea/email.py:129
+#: apps/plea/email.py:121
 #: apps/plea/templates/emails/user_plea_confirmation.html:7
 msgid "Online plea submission confirmation"
 msgstr ""
@@ -981,7 +981,7 @@ msgstr ""
 msgid "On page 1, usually at the top."
 msgstr ""
 
-#: apps/plea/stages.py:365
+#: apps/plea/stages.py:373
 msgid ""
 "There seems to have been a problem submitting your plea. Please try again."
 msgstr ""
@@ -1085,145 +1085,120 @@ msgid "From the first 12 months' trading projections, tell us:"
 msgstr ""
 
 #: apps/plea/templates/complete.html:7 apps/plea/templates/complete.html:18
-#: apps/plea/templates/emails/user_plea_confirmation.html:18
-#: apps/plea/templates/emails/user_plea_confirmation.txt:3
-msgid "Your plea has been sent to the court"
-msgid_plural "Your pleas have been sent to the court"
+msgid "Your plea has been sent to the magistrate"
+msgid_plural "Your pleas have been sent to the magistrate"
 msgstr[0] ""
 msgstr[1] ""
 
 #: apps/plea/templates/complete.html:20
-#: apps/plea/templates/emails/user_plea_confirmation.html:20
-#: apps/plea/templates/emails/user_plea_confirmation.txt:3
-msgid "Your company's plea has been sent to the court"
-msgid_plural "Your company's pleas have been sent to the court"
+msgid "Your company's plea has been sent to the magistrate"
+msgid_plural "Your company's pleas have been sent to the magistrate"
 msgstr[0] ""
 msgstr[1] ""
 
 #: apps/plea/templates/complete.html:27
-#: apps/plea/templates/emails/user_plea_confirmation.html:24
-#: apps/plea/templates/emails/user_plea_confirmation.txt:7
+#: apps/plea/templates/emails/user_plea_confirmation.html:18
 msgid "What happens next:"
 msgstr ""
 
-#: apps/plea/templates/complete.html:32
-#: apps/plea/templates/emails/user_plea_confirmation.html:29
-#: apps/plea/templates/emails/user_plea_confirmation.txt:8
-msgid ""
-"we'll send you a letter with the court's decision within 3 working days "
-"after your hearing date"
-msgid_plural ""
-"we'll send you a letter with the court's decisions within 3 working days "
-"after your hearing date"
+#: apps/plea/templates/complete.html:33
+#: apps/plea/templates/emails/user_plea_confirmation.html:24
+#: apps/plea/templates/emails/user_plea_confirmation.txt:7
+msgid "we'll send you a letter with the magistrate's decision"
+msgid_plural "we'll send you a letter with the magistrate's decisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/plea/templates/complete.html:33
-#: apps/plea/templates/emails/user_plea_confirmation.html:30
-#: apps/plea/templates/emails/user_plea_confirmation.txt:9
+#: apps/plea/templates/complete.html:34
+#: apps/plea/templates/emails/user_plea_confirmation.html:25
+#: apps/plea/templates/emails/user_plea_confirmation.txt:8
 msgid ""
 "we'll tell you if you need to attend a trial and what evidence you may need "
 "to send to the court to support your case"
 msgstr ""
 
-#: apps/plea/templates/complete.html:37
-#: apps/plea/templates/emails/user_plea_confirmation.html:34
-#: apps/plea/templates/emails/user_plea_confirmation.txt:10
+#: apps/plea/templates/complete.html:38
+#: apps/plea/templates/emails/user_plea_confirmation.html:29
+#: apps/plea/templates/emails/user_plea_confirmation.txt:9
 msgid ""
-"we'll send a letter with the court's decision within 3 working days after "
-"the hearing date"
-msgid_plural ""
-"we'll send a letter with the court's decisions within 3 working days after "
-"the hearing date"
+"we'll send you a letter with a hearing date for you to come to court for a "
+"trial"
+msgstr ""
+
+#: apps/plea/templates/complete.html:46
+#: apps/plea/templates/emails/user_plea_confirmation.html:37
+#: apps/plea/templates/emails/user_plea_confirmation.txt:10
+msgid "we'll send a letter with the magistrate's decision"
+msgid_plural "we'll send a letter with the magistrate's decisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apps/plea/templates/complete.html:38
-#: apps/plea/templates/emails/user_plea_confirmation.html:35
+#: apps/plea/templates/complete.html:47
+#: apps/plea/templates/emails/user_plea_confirmation.html:38
 #: apps/plea/templates/emails/user_plea_confirmation.txt:11
 msgid ""
 "we'll tell you if a company representative needs to attend a trial and what "
 "evidence you may need to send to the court to support the case"
 msgstr ""
 
-#: apps/plea/templates/complete.html:44
-#: apps/plea/templates/emails/user_plea_confirmation.html:41
+#: apps/plea/templates/complete.html:51
+#: apps/plea/templates/emails/user_plea_confirmation.html:42
 #: apps/plea/templates/emails/user_plea_confirmation.txt:12
 msgid ""
-"we'll send you a letter with a new hearing date for you to come to court for "
-"a trial"
+"we'll send you a letter with a hearing date for a company representative to "
+"attend a trial"
 msgstr ""
 
-#: apps/plea/templates/complete.html:48
-#: apps/plea/templates/emails/user_plea_confirmation.html:45
-#: apps/plea/templates/emails/user_plea_confirmation.txt:13
-msgid ""
-"we'll send you a letter with a new hearing date for a company representative "
-"to come to court"
-msgstr ""
-
-#: apps/plea/templates/complete.html:52
+#: apps/plea/templates/complete.html:56
 msgid ""
 "you can <a href=\"javascript:window.print();\">print a copy</a> of this plea "
 "confirmation for your records"
 msgstr ""
 
-#: apps/plea/templates/complete.html:57
-#: apps/plea/templates/emails/user_plea_confirmation.html:52
-#: apps/plea/templates/emails/user_plea_confirmation.txt:16
-msgid "Do not:"
+#: apps/plea/templates/complete.html:61
+#: apps/plea/templates/emails/user_plea_confirmation.html:51
+#: apps/plea/templates/emails/user_plea_confirmation.txt:15
+msgid ""
+"Do not send your driving licence to the court. The DVLA will contact you if "
+"they need you to send it to them."
 msgstr ""
 
-#: apps/plea/templates/complete.html:60
+#: apps/plea/templates/complete.html:64
 #: apps/plea/templates/emails/user_plea_confirmation.html:54
-#: apps/plea/templates/emails/user_plea_confirmation.txt:17
-msgid ""
-"come to court on the hearing date shown on page 1 of the requisition notice "
-"we sent to you"
-msgstr ""
-
-#: apps/plea/templates/complete.html:63
-#: apps/plea/templates/emails/user_plea_confirmation.html:57
-#: apps/plea/templates/emails/user_plea_confirmation.txt:18
-msgid ""
-"send your driving licence to the court, the DVLA will contact you if they "
-"need you to send it to them"
-msgstr ""
-
-#: apps/plea/templates/complete.html:68
-#: apps/plea/templates/emails/user_plea_confirmation.html:61
-#: apps/plea/templates/emails/user_plea_confirmation.txt:22
+#: apps/plea/templates/emails/user_plea_confirmation.txt:19
 msgid "Need to change a plea?"
 msgstr ""
 
-#: apps/plea/templates/complete.html:70
-#: apps/plea/templates/emails/user_plea_confirmation.html:63
-#: apps/plea/templates/emails/user_plea_confirmation.txt:23
+#: apps/plea/templates/complete.html:66
+#: apps/plea/templates/emails/user_plea_confirmation.html:56
+#: apps/plea/templates/emails/user_plea_confirmation.txt:20
 #, python-format
 msgid ""
 "Contact the court by post or email quoting your URN %(urn)s to arrive before "
-"%(hearing_date)s."
+"%(contact_deadline)s."
 msgstr ""
 
-#: apps/plea/templates/complete.html:72
-#: apps/plea/templates/emails/user_plea_confirmation.html:65
-#: apps/plea/templates/emails/user_plea_confirmation.txt:25
+#: apps/plea/templates/complete.html:68
+#: apps/plea/templates/emails/user_plea_confirmation.html:58
+#: apps/plea/templates/emails/user_plea_confirmation.txt:22
 msgid "The contact details for the court are:"
 msgstr ""
 
-#: apps/plea/templates/complete.html:74
+#: apps/plea/templates/complete.html:70
 #: apps/plea/templates/court_finder.html:21
+#: apps/plea/templates/emails/user_plea_confirmation.html:60
+#: apps/plea/templates/emails/user_plea_confirmation.txt:24
 msgid "By post:"
 msgstr ""
 
-#: apps/plea/templates/complete.html:78
+#: apps/plea/templates/complete.html:74
 #: apps/plea/templates/court_finder.html:26
-#: apps/plea/templates/emails/user_plea_confirmation.html:70
-#: apps/plea/templates/emails/user_plea_confirmation.txt:30
+#: apps/plea/templates/emails/user_plea_confirmation.html:63
+#: apps/plea/templates/emails/user_plea_confirmation.txt:27
 msgid "By email:"
 msgstr ""
 
-#: apps/plea/templates/complete.html:82
+#: apps/plea/templates/complete.html:78
 msgid "Finish"
 msgstr ""
 
@@ -1317,22 +1292,24 @@ msgstr ""
 msgid "Company financial details"
 msgstr ""
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:49
-#: apps/plea/templates/emails/user_plea_confirmation.txt:14
+#: apps/plea/templates/emails/user_plea_confirmation.html:16
+#: apps/plea/templates/emails/user_plea_confirmation.txt:3
+msgid "Your online plea has been submitted"
+msgid_plural "Your online pleas have been submitted"
+msgstr[0] ""
+msgstr[1] ""
+
+#: apps/plea/templates/emails/user_plea_confirmation.html:47
+#: apps/plea/templates/emails/user_plea_confirmation.txt:13
 msgid "you can print a copy of this plea confirmation for your records"
 msgstr ""
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:67
-#: apps/plea/templates/emails/user_plea_confirmation.txt:27
-msgid "By Post:"
-msgstr ""
-
-#: apps/plea/templates/emails/user_plea_confirmation.html:73
-#: apps/plea/templates/emails/user_plea_confirmation.txt:35
+#: apps/plea/templates/emails/user_plea_confirmation.html:66
+#: apps/plea/templates/emails/user_plea_confirmation.txt:32
 msgid "We're constantly working to improve this service."
 msgstr ""
 
-#: apps/plea/templates/emails/user_plea_confirmation.html:75
+#: apps/plea/templates/emails/user_plea_confirmation.html:68
 msgid ""
 "Please give us <a href=\"/feedback/\">feedback</a> so we can make it better."
 msgstr ""
@@ -1341,26 +1318,26 @@ msgstr ""
 msgid "GOV.UK - Online plea submission confirmation"
 msgstr ""
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:37
+#: apps/plea/templates/emails/user_plea_confirmation.txt:34
 msgid "Please give us feedback so we can make it better:"
+msgstr ""
+
+#: apps/plea/templates/emails/user_plea_confirmation.txt:39
+#: make_a_plea/templates/base_user_email.html:192
+msgid "If you're unsure an email is from the Ministry of Justice:"
+msgstr ""
+
+#: apps/plea/templates/emails/user_plea_confirmation.txt:41
+#: make_a_plea/templates/base_user_email.html:195
+msgid "do not reply to it or click any links"
 msgstr ""
 
 #: apps/plea/templates/emails/user_plea_confirmation.txt:42
 #: make_a_plea/templates/base_user_email.html:196
-msgid "If you're unsure an email is from the Ministry of Justice:"
-msgstr ""
-
-#: apps/plea/templates/emails/user_plea_confirmation.txt:44
-#: make_a_plea/templates/base_user_email.html:199
-msgid "do not reply to it or click any links"
-msgstr ""
-
-#: apps/plea/templates/emails/user_plea_confirmation.txt:45
-#: make_a_plea/templates/base_user_email.html:200
 msgid "forward it to"
 msgstr ""
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:47
+#: apps/plea/templates/emails/user_plea_confirmation.txt:44
 msgid "Terms and Conditions and Privacy Policy:"
 msgstr ""
 
@@ -1911,7 +1888,7 @@ msgstr ""
 msgid "You have entered some information"
 msgstr ""
 
-#: make_a_plea/templates/base_user_email.html:203
+#: make_a_plea/templates/base_user_email.html:199
 msgid "Terms and Conditions and privacy policy"
 msgstr ""
 

--- a/make_a_plea/templates/base_user_email.html
+++ b/make_a_plea/templates/base_user_email.html
@@ -194,7 +194,7 @@
 
                 <ul>
                     <li>{% blocktrans %}do not reply to it or click any links{% endblocktrans %}</li>
-                    <li>{% blocktrans %}forward it to{% endblocktrans %} <a href="mailto:feedback@makeaplea.gov.uk">feedback@makeaplea.gov.uk</a></li>
+                    <li>{% blocktrans %}forward it to{% endblocktrans %} <a href="mailto:makeaplea@justice.gov.uk">makeaplea@justice.gov.uk</a></li>
                 </ul>
 
                 <p><a href="/terms-and-conditions-and-privacy-policy">{% blocktrans %}Terms and Conditions and privacy policy{% endblocktrans %}</a></p>

--- a/make_a_plea/templates/base_user_email.html
+++ b/make_a_plea/templates/base_user_email.html
@@ -7,9 +7,9 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
+
   <title>{% block subject %}Make a Plea - GOV.UK{% endblock subject %}</title>
-  
+
   <style type="text/css">
       /* Clients overrides */
       @-ms-viewport {width: device-width;} /* Windows Phone 8 responsiveness */
@@ -52,25 +52,26 @@
       }
 
       h1 {
-        font-size: 32px;
+        font-size: 36px;
         margin: 10px 0 18px;
       }
 
-      h2 {
-        font-size: 28px;
+      h2,
+      p.lede {
+        font-size: 24px;
         margin: 36px 0 18px;
       }
 
       h3 {
-        font-size: 22px;
-        margin: 36px 0 18px;
+        font-size: 18px;
+        margin: 18px 0 0;
       }
 
       p {
         font-family: Arial, sans-serif;
         font-size: 18px;
         line-height: 1.25;
-        margin: 18px 0;
+        margin: 0 0 18px;
         color: #000000;
       }
 
@@ -95,11 +96,6 @@
         color: #005ea5;
       }
 
-      /* Modifiers */
-      p.lede {
-        font-size: 22px;
-      }
-   
 
       /* Main areas */
       #headerCell {
@@ -149,12 +145,13 @@
         color: #777777;
       }
 
+      {% block extra_css %}{% endblock extra_css %}
 
       /* Responsiveness */
       /* Fix for Apple Mail, which does not respect max-width but does media queries */
       @media screen and (min-width: 601px) {
           .templateContainer {
-              width: 560px !important;
+              width: 580px !important;
           }
       }
 
@@ -162,7 +159,7 @@
 </head>
 <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
   <center>
-    <table align="center" border="0" cellpadding="20" cellspacing="0" height="100%" width="100%">
+    <table align="center" border="0" cellpadding="10" cellspacing="0" height="100%" width="100%">
       <tr>
         <td align="center" valign="top" id="bodyCell">
 

--- a/make_a_plea/views.py
+++ b/make_a_plea/views.py
@@ -130,7 +130,7 @@ def test_template(request):
     case_data = {"plea_made_by": options["plea_made_by"][plea_made_by],
                  "urn": "51/aa/00000/00",
                  "number_of_charges": int(number_of_charges),
-                 "date_of_hearing": "2015-11-17"}
+                 "contact_deadline": "2015-11-17"}
 
     court_data = {"court_address": "Court address\nSome Place\nT357TER",
                   "court_email": "email@court.com"}


### PR DESCRIPTION
Copy updates
Contact deadline gets set when saving the Case stage: it is either the
hearing date for non-SJP cases, or the posting date +28 days for SJP
cases.

Note: this contact deadline date is used for the Court Email Count stats
when the case is SJP.

[MAPDEV430]

Update User confirmation email
    
Copy updates for both Defendant and Company journeys.
    
Remove capitalised 'Post'
    
Some small style updates:
- Extra CSS content block for more granular styling in various templates
- H1 heading now 36px
- H2 headings font-size now 24px
- Main padding around email content is now 10px for better use of screen real estate on smaller devices
- Smaller headings ("By post:" and "By email:") are now H3.
    
[MAPDEV431]