### PR TITLE
Set cache middleware default to 0 seconds

### DIFF
--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse_lazy, reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import RequestContext
-from django.views.decorators.cache import never_cache
 
 from apps.forms.stages import MultiStageForm
 from apps.forms.views import StorageView
@@ -19,10 +18,6 @@ class FeedbackForms(MultiStageForm):
 
 
 class FeedbackViews(StorageView):
-
-    @method_decorator(never_cache)
-    def dispatch(self, *args, **kwargs):
-        return super(FeedbackViews, self).dispatch(*args, **kwargs)
 
     def get(self, request, stage=None):
         storage = self._get_storage(request, "feedback_data")

--- a/apps/monitoring/views.py
+++ b/apps/monitoring/views.py
@@ -3,8 +3,6 @@ from urlparse import urljoin
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
 from django.views.generic import View
 
 from .check_methods import *
@@ -42,12 +40,3 @@ class HealthCheckView(View):
         status["ok"] = all(item[1]["ok"] for item in status.items())
 
         return HttpResponse(json.dumps(status), content_type="application/json")
-
-    @method_decorator(never_cache)
-    def dispatch(self, *args, **kwargs):
-        return super(HealthCheckView, self).dispatch(*args, **kwargs)
-
-
-
-
-

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
 from django.shortcuts import RequestContext, redirect
-from django.views.decorators.cache import never_cache
-from django.views.generic import TemplateView, FormView
+from django.views.generic import FormView
 
 from brake.decorators import ratelimit
 
@@ -70,10 +69,6 @@ class PleaOnlineForms(MultiStageForm):
 
 
 class PleaOnlineViews(StorageView):
-
-    @method_decorator(never_cache)
-    def dispatch(self, *args, **kwargs):
-        return super(PleaOnlineViews, self).dispatch(*args, **kwargs)
 
     def get(self, request, stage=None):
         storage = self._get_storage(request, "plea_data")

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -131,7 +131,6 @@ TEMPLATE_LOADERS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.cache.UpdateCacheMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -141,7 +140,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'make_a_plea.middleware.AdminLocaleURLMiddleware',
     'make_a_plea.middleware.TimeoutRedirectMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
+
+CACHE_MIDDLEWARE_SECONDS = 0
 
 ROOT_URLCONF = 'make_a_plea.urls'
 

--- a/make_a_plea/urls.py
+++ b/make_a_plea/urls.py
@@ -17,7 +17,7 @@ handler500 = "make_a_plea.views.server_error"
 
 urlpatterns = patterns(
     "",
-    url(r"^$", views.HomeView.as_view(), name="home"),
+    url(r"^$", TemplateView.as_view(template_name="start.html"), name="home"),
     url(r"^helping-you-plead-online/$", views.TranslatedView.as_view(template_name="ad_support.html"), name="ad_support"),
     url(r"^terms-and-conditions-and-privacy-policy/$", views.TranslatedView.as_view(template_name="terms.html"), name="terms"),
     url(r"^plea/", include("apps.plea.urls", )),

--- a/make_a_plea/views.py
+++ b/make_a_plea/views.py
@@ -2,23 +2,10 @@ from django.conf import settings
 from django import http
 from django.shortcuts import render
 from django.utils.http import is_safe_url
-from django.utils.translation import check_for_language, to_locale, get_language
+from django.utils.translation import check_for_language, get_language
 from django.views.generic import TemplateView
-from django.views.decorators.cache import never_cache
 
 from waffle.decorators import waffle_switch
-
-
-
-class HomeView(TemplateView):
-    """
-    Home page view.
-    """
-    template_name = "start.html"
-
-    def get(self, request, *args, **kwargs):
-
-        return super(HomeView, self).get(request, *args, **kwargs)
 
 
 class TranslatedView(TemplateView):
@@ -92,7 +79,6 @@ def set_a11y_testing(request):
     return response
 
 
-@never_cache
 @waffle_switch("test_template")
 def test_template(request):
     """


### PR DESCRIPTION
This update applies a cache-control max-age of 0 to all requests, and
should prevent a Safari bug where the browser is aggressively caching
previously requested pages.

This also removes the need for a lot of the 'never_cache' method
decorators on dispatch definitions -- the HomeView has also been removed
and replaced with a standard TemplateView.

[MAPDEV448]