### PR TITLE
MAPDEV447 feedback email field

### DIFF
--- a/apps/feedback/templates/comments.html
+++ b/apps/feedback/templates/comments.html
@@ -12,9 +12,7 @@
 {% block stage_form %}
     {% std_field form.comments %}
 
-    {% if service.used_call_centre == False %}
-        {% std_field form.email %}
-    {% endif %}
+    {% std_field form.email %}
 {% endblock stage_form %}
 
 {% block stage_submit %}

--- a/apps/feedback/templates/emails/feedback_summary.html
+++ b/apps/feedback/templates/emails/feedback_summary.html
@@ -15,14 +15,12 @@
     </tr>
     <tr>
         <th valign="top" align="right">Comments</th>
-        <td>{{ comments|linebreaksbr }}</td>
+        <td>{{ comments|linebreaksbr|default:"-" }}</td>
     </tr>
-    {% if email %}
     <tr>
         <th valign="top" align="right">Email</th>
-        <td>{{ email }}</td>
+        <td>{{ email|default:"-" }}</td>
     </tr>
-    {% endif %}
 </table>
 
 <p>

--- a/apps/feedback/tests.py
+++ b/apps/feedback/tests.py
@@ -81,7 +81,7 @@ class FeedbackFormTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(form.current_stage.form.errors), 1)
 
-    def test_comments_stage_shows_email(self):
+    def test_comments_stage_loads(self):
         session_data = {
             "service": {
                 "complete": True,
@@ -94,24 +94,8 @@ class FeedbackFormTestCase(TestCase):
         form.load(self.request_context)
 
         response = form.render()
-        self.assertIn("Email address", response.content)
-
-    def test_comments_stage_hides_email(self):
-        session_data = {
-            "service": {
-                "complete": True,
-                "used_call_centre": True,
-                "call_centre_satisfaction": 5,
-                "service_satisfaction": 3
-            }
-        }
-
-        form = FeedbackForms(session_data, "comments")
-        form.load(self.request_context)
-
-        with self.assertTemplateUsed("comments.html"):
-            response = form.render()
-            self.assertNotIn("Email address", response.content)
+        self.assertIn('id="id_comments"', response.content)
+        self.assertIn('id="id_email"', response.content)
 
     def test_email_is_sent(self):
         form = FeedbackForms(self.complete_session_data, "comments")


### PR DESCRIPTION
Email field now always shows, previously was hidden when user had
selected they had used the call centre.
Removed test for show/hide email field, replaced with form loading test.
Updated feedback email to always include Comments and Email, but
defaulted to "-".

[MAPDEV447]