### PR TITLE
Mapdev463 feedback redirect

### DIFF
--- a/apps/feedback/tests.py
+++ b/apps/feedback/tests.py
@@ -124,6 +124,16 @@ class FeedbackFormTestCase(TestCase):
         self.assertEquals(response.status_code, 302)
         self.assertEquals(response.url, "/terms-and-conditions-and-privacy-policy/")
 
+    def test_redirect_is_set_to_home_if_complete_stage(self):
+        fake_request = self.get_request_mock("/feedback/?next=plea_form_step&stage=complete")
+        fake_request.session = {"feedback_data": self.complete_session_data}
+
+        view = FeedbackViews()
+        response = view.get(fake_request, stage="complete")
+
+        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response.url, "/")
+
     def test_user_rating_is_recorded(self):
         form = FeedbackForms(self.complete_session_data, "comments")
         form.save({}, self.request_context)

--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -28,6 +28,12 @@ class FeedbackViews(StorageView):
             nxt = kw_args.pop("next")
             if kw_args:
                 redirect_url = reverse(nxt, kwargs=kw_args)
+
+                try:
+                    if kw_args["stage"] == "complete":
+                        redirect_url = "/"
+                except KeyError:
+                    pass
             else:
                 redirect_url = reverse(nxt)
 

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -426,8 +426,7 @@ class ReviewStage(FormStage):
             self.all_data["case"]["urn"]
         except KeyError:
             # session has timed out
-            self.add_message(messages.ERROR, "Your session has timed out",
-                             extra_tags="session_timeout")
+            self.add_message(messages.ERROR, _("Your session has timed out"), extra_tags="session_timeout")
 
             self.set_next_step("case")
             return clean_data

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -1,8 +1,10 @@
 from django.utils.decorators import method_decorator
 from django.conf import settings
+from django.contrib import messages
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
 from django.shortcuts import RequestContext, redirect
+from django.utils.translation import ugettext as _
 from django.views.generic import FormView
 
 from brake.decorators import ratelimit
@@ -79,9 +81,10 @@ class PleaOnlineViews(StorageView):
         self.storage = None
 
     def dispatch(self, request, *args, **kwargs):
-        # If the session has timed out, redirect to case
-        if not request.session.get("plea_data") and kwargs.get("stage") != "notice_type":
-            return HttpResponseRedirect(reverse_lazy("plea_form_step", args=("notice_type",)))
+        # If the session has timed out, redirect to start page
+        if not request.session.get("plea_data") and kwargs.get("stage", "notice_type") != "notice_type":
+            messages.add_message(request, messages.ERROR, _("Your session has timed out"), extra_tags="session_timeout")
+            return HttpResponseRedirect("/")
 
         # Store the index if we've got one
         idx = kwargs.pop("index", None)

--- a/make_a_plea/templates/base.html
+++ b/make_a_plea/templates/base.html
@@ -50,7 +50,7 @@
             {% if "error" in message.tags %}
             <section class="error-summary">
                 {% if "session_timeout" in message.tags %}
-                <h1>{% blocktrans %}Session timeout{% endblocktrans %}</h1>
+                <h1 class="heading-medium">{% blocktrans %}Session timeout{% endblocktrans %}</h1>
                 <p>{% blocktrans %}Your session has expired, re-enter your details and try again.{% endblocktrans %}</p>
                 {% else %}
                 {{ message|safe }}


### PR DESCRIPTION
Completing the feedback form just after a successful submission was redirecting the user to the Notice Type screen, when they should be redirected to the Start screen instead.

When session is missing, the user is now also redirected to the start page rather than the first stage, but is also shown a message about the session having timed out.

[MAPDEV463]