### PR TITLE
Fix missing dependencies for Company Finances

### DIFF
--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -264,7 +264,7 @@ class CompanyFinancesStage(FormStage):
     name = "company_finances"
     template = "company_finances.html"
     form_class = CompanyFinancesForm
-    dependencies = ["notice_type", "case"]
+    dependencies = ["notice_type", "case", "company_details", "plea"]
 
 
 class YourStatusStage(FormStage):

--- a/apps/plea/tests/test_nojs.py
+++ b/apps/plea/tests/test_nojs.py
@@ -22,7 +22,8 @@ class TestNoJS(TestCase):
                                                   "plea_made_by": "Company representative"},
                                          "company_details": {"complete": True},
                                          "plea": {"complete": True,
-                                                  "data": [{"guilty": "guilty"}]}}
+                                                  "data": [{"guilty": "guilty",
+                                                            "complete": True}]}}
 
         self.request_context = {}
 


### PR DESCRIPTION
Dependencies on "company_details" and "plea" stages were missing for the company finances stage,
meaning it was accessible without completing these.

[hotfix]