### PR TITLE
Mapdev503 sjp user journey for lh

### DIFF
--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -10,7 +10,7 @@ class UsageStatsAdmin(admin.ModelAdmin):
 
 class CourtAdmin(admin.ModelAdmin):
     list_display = ('court_name', 'region_code', 'court_address', 'court_email', 'plp_email',
-                    'enabled', 'test_mode', 'sjp_area')
+                    'enabled', 'test_mode', 'notice_types')
 
 
 class InlineCaseAction(admin.TabularInline):

--- a/apps/plea/migrations/0012_court_notice_types.py
+++ b/apps/plea/migrations/0012_court_notice_types.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0011_court_sjp_area'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='court',
+            name='notice_types',
+            field=models.CharField(default=b'both', help_text=b'What kind of notices are being sent out by this area?', max_length=7, choices=[(b'both', b'Both'), (b'sjp', b'SJP'), (b'non-sjp', b'Non-SJP')]),
+        ),
+    ]

--- a/apps/plea/migrations/0013_remove_court_sjp_area.py
+++ b/apps/plea/migrations/0013_remove_court_sjp_area.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0012_court_notice_types'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='court',
+            name='sjp_area',
+        ),
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -25,6 +25,9 @@ INITIATION_TYPE_CHOICES = (("C", "Charge"),
                            ("R", "Remitted"),
                            ("S", "Summons"))
 
+NOTICE_TYPES_CHOICES = (("both", "Both"),
+                        ("sjp", "SJP"),
+                        ("non-sjp", "Non-SJP"))
 
 def get_totals(qs):
     totals = qs.aggregate(Sum('total_pleas'),
@@ -435,6 +438,11 @@ class Court(models.Model):
     test_mode = models.BooleanField(
         default=False,
         help_text="Is this court entry used for testing purposes?")
+
+    notice_types = models.CharField(
+        max_length=7, null=False, blank=False, default="both",
+        choices=NOTICE_TYPES_CHOICES,
+        help_text="What kind of notices are being sent out by this area?")
 
     sjp_area = models.BooleanField(
         default=False,

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -444,10 +444,6 @@ class Court(models.Model):
         choices=NOTICE_TYPES_CHOICES,
         help_text="What kind of notices are being sent out by this area?")
 
-    sjp_area = models.BooleanField(
-        default=False,
-        help_text="Is this area sending out SJP notices?")
-
     validate_urn = models.BooleanField(
         default=False,
         help_text="Do we have a full set of incoming DX data?"

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -132,6 +132,79 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
             }
         }
 
+    def test_urn_entry_sjp_only_sets_notice_type(self):
+        Court.objects.create(court_code="0000",
+                             region_code="99",
+                             court_name="SJP only court",
+                             court_address="test address",
+                             court_telephone="0800 MAKEAPLEA",
+                             court_email="test@test.com",
+                             submission_email="test@test.com",
+                             plp_email="test@test.com",
+                             enabled=True,
+                             test_mode=False,
+                             notice_types="sjp")
+
+        form = PleaOnlineForms(self.session, "enter_urn")
+        form.load(self.request_context)
+        form.save({"urn": "99/AA/00000/00"}, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(form.all_data["notice_type"]["complete"], True)
+        self.assertEqual(form.all_data["notice_type"]["auto_set"], True)
+        self.assertEqual(form.all_data["notice_type"]["sjp"], True)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/plea/case/")
+
+    def test_urn_entry_non_sjp_only_sets_notice_type(self):
+        Court.objects.create(court_code="0000",
+                             region_code="98",
+                             court_name="Non-SJP only court",
+                             court_address="test address",
+                             court_telephone="0800 MAKEAPLEA",
+                             court_email="test@test.com",
+                             submission_email="test@test.com",
+                             plp_email="test@test.com",
+                             enabled=True,
+                             test_mode=False,
+                             notice_types="non-sjp")
+
+        form = PleaOnlineForms(self.session, "enter_urn")
+        form.load(self.request_context)
+        form.save({"urn": "98/AA/00000/00"}, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(form.all_data["notice_type"]["complete"], True)
+        self.assertEqual(form.all_data["notice_type"]["auto_set"], True)
+        self.assertEqual(form.all_data["notice_type"]["sjp"], False)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/plea/case/")
+
+    def test_urn_entry_both_shows_notice_type(self):
+        form = PleaOnlineForms(self.session, "enter_urn")
+        form.load(self.request_context)
+        form.save({"urn": "06/AA/00000/00"}, self.request_context)
+
+        response = form.render()
+
+        self.assertEqual(form.all_data.get("notice_type", {}).get("auto_set", None), None)
+        self.assertEqual(form.all_data.get("notice_type", {}).get("sjp", None), None)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/plea/notice_type/")
+
+    def test_auto_set_notice_type_prevents_notice_type_stage_access(self):
+        self.session.update({"case": {"urn": "99/AA/00000/00"},
+                             "notice_type": {"auto_set": True}})
+
+        form = PleaOnlineForms(self.session, "notice_type")
+        form.load(self.request_context)
+        response = form.render()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/plea/case/")
+
     def test_notice_type_stage_missing_data(self):
         form = PleaOnlineForms(self.session, "notice_type")
         form.load(self.request_context)
@@ -166,8 +239,6 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
         case.urn = "06/AA/0000000/00"
         case.sent = True
         case.save()
-
-        hearing_date = datetime.date.today()+datetime.timedelta(30)
 
         form = PleaOnlineForms(self.session, "enter_urn")
         form.load(request_context)


### PR DESCRIPTION
The SJP area setting has been replaced by a more modular Notice Types setting, which can be set to 'SJP', 'Non-SJP' or 'Both'.

When the user submits URN, if the Court is set to accept either only SJP notices or only non-SJP notices, the Notice Type is automatically set and the Notice Type stage is skipped. If a URN for a Court accepting both is submitted, then the Notice Type screen is still shown.

If the Notice Type has been set automatically as above, trying to access the Notice Type screen redirects the User to the Case screen.