### PR TITLE
Move case sent update to court email send

### DIFF
--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -82,9 +82,6 @@ def send_plea_email(context_data):
     case.language = translation.get_language().split("-")[0]
     case.save()
 
-    if "court" in context_data:
-        del context_data["court"]
-
     if getattr(settings, "STORE_USER_DATA", False):
         encrypt_and_store_user_data(case.urn, case.id, context_data)
 
@@ -136,12 +133,5 @@ def send_plea_email(context_data):
 
     else:
         case.add_action("No email entered, user email not sent", "")
-
-    if not court_obj.test_mode:
-        case.sent = True
-        email_count.sent = True
-        email_count.save()
-
-    case.save()
 
     return True

--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -75,10 +75,11 @@ def email_send_court(self, case_id, count_id, email_data):
         raise self.retry(args=[case_id, count_id, email_data], exc=exc)
 
     case.add_action("Court email sent", "Sent mail to {0} via {1}".format(plea_email_to, smtp_route))
-    case.sent = True
-    case.save()
 
     if not court_obj.test_mode:
+        case.sent = True
+        case.save()
+
         email_count.get_status_from_case(case)
         email_count.save()
 


### PR DESCRIPTION
Setting the case 'sent' flag in the main email script was being
superseded by the Court email task. This task now checks for the court
test mode before attempting to set the flag: if the court is in test
mode, the case isn't marked as sent, allowing the URN to be reuse for
multiple tests.

[MAPDEV506]