### PR TITLE
Fix test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ coverage.xml
 /user_data
 /test_user_data
 /test_gpg_home
+make_a_plea/test_gpg_home
+make_a_plea/test_user_data
 
 # local version of moj_template
 moj_template/

--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -16,7 +16,6 @@ INSTALLED_APPS = (
 )
 
 PROJECT_APPS = (
-    'moj_template',
     'apps.forms',
     'apps.plea',
     'api',

--- a/api/settings/testing.py
+++ b/api/settings/testing.py
@@ -8,11 +8,11 @@ ADMINS = (
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'manchester_traffic_offences',
-        'USER': 'jenkins',
-        'PASSWORD': 'moomoo',
-        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',                      # Set to empty string for default.
+        'NAME': os.environ.get('POSTGRES_DB','manchester_traffic_offences'),
+        'USER': os.environ.get('POSTGRES_USER', 'jenkins'),
+        'PASSWORD': os.environ.get('POSTGRES_PASS', 'moomoo'),
+        'HOST': os.environ.get('POSTGRES_HOST', ''),
+        'PORT': os.environ.get('POSTGRES_PORT', ''),
     }
 }
 

--- a/run_api_tests.sh
+++ b/run_api_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-python manage.py test --settings=api.settings.base -p api_test_*.py
+pip install -r requirements/testing.txt
 
-
+python ./manage.py test --settings=api.settings.base -p api_test_*.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,10 +7,4 @@ export DJANGO_SETTINGS_MODULE
 pip install -r requirements/testing.txt
 python ./manage.py compilemessages
 python ./manage.py test
-
-#
-# XXX:
-#      API testing should be enabled, but as of this commit API tests are broken.
-#      Leaving this here for future reference.
-
-# python ./manage.py test --settings=api.settings.testing -p api_test_*.py
+python ./manage.py test --settings=api.settings.testing -p api_test_*.py


### PR DESCRIPTION
- Remove unnecessary project_app dependency on moj_template
- Add environment variables DB settings to API testing settings
- Add pip install to API test script
- Uncomment API testing from main test script

[hotfix]