### PR TITLE
Add Feedback submission confirmation screen

### DIFF
--- a/apps/feedback/email.py
+++ b/apps/feedback/email.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 
 def send_feedback_email(email_data):
     email_context = {"used_call_centre": email_data["service"]["used_call_centre"],
-                     "call_centre_satisfaction": email_data["service"]["call_centre_satisfaction"],
+                     "call_centre_satisfaction": email_data["service"].get("call_centre_satisfaction", ""),
                      "service_satisfaction": email_data["service"]["service_satisfaction"],
                      "comments": email_data["comments"]["comments"],
                      "email": email_data["comments"]["email"],
@@ -20,7 +20,7 @@ def send_feedback_email(email_data):
                                           email_context),
                          settings.FEEDBACK_EMAIL_FROM,
                          settings.FEEDBACK_EMAIL_TO)
-    
+
     email.content_subtype = "html"
     email.send(fail_silently=False)
 

--- a/apps/feedback/stages.py
+++ b/apps/feedback/stages.py
@@ -29,20 +29,25 @@ class CommentsStage(FormStage):
             email_data.update({"comments": clean_data})
             email_result = send_feedback_email(email_data)
             if email_result:
-                self.add_message(messages.SUCCESS, _("Your feedback has been submitted"))
-                UserRating.objects.record(self.all_data["service"]["service_satisfaction"], self.all_data["service"]["call_centre_satisfaction"])
+                UserRating.objects.record(self.all_data["service"]["service_satisfaction"],
+                                          self.all_data["service"].get("call_centre_satisfaction", ""))
                 self.set_next_step("complete")
             else:
                 self.add_message(messages.ERROR, '<h1>{}</h1><p>{}</p>'.format(
                     _("Submission Error"),
                     _("There seems to have been a problem submitting your feedback. Please try again.")))
-                self.set_next_step("comments")
 
         return clean_data
 
 
 class CompleteStage(FormStage):
     name = "complete"
-    template = None
+    template = "complete_feedback.html"
     form_class = None
     dependencies = ["service", "comments"]
+
+    def render(self, request_context):
+
+        self.context["feedback_redirect"] = self.all_data.get("feedback_redirect", "/")
+
+        return super(CompleteStage, self).render(request_context)

--- a/apps/feedback/templates/complete_feedback.html
+++ b/apps/feedback/templates/complete_feedback.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load form_widgets %}
+
+{% block page_title %}{% blocktrans %}Your feedback has been submitted{% endblocktrans %} - {{ block.super }}{% endblock %}
+
+{% block page_content %}
+
+    <header class="success-header" role="alert">
+        <h1 class="ticked">{% blocktrans %}Your feedback has been submitted{% endblocktrans %}</h1>
+    </header>
+
+    <section>
+        <p><a class="button" href="{{ feedback_redirect }}">Finish</a></p>
+    </section>
+
+{% endblock page_content %}

--- a/make_a_plea/settings/production.py
+++ b/make_a_plea/settings/production.py
@@ -39,3 +39,5 @@ STORE_USER_DATA = True
 ENCRYPTED_COOKIE_KEYS = [
     os.environ["ENCRYPTED_COOKIE_KEY"]
 ]
+
+REDIRECT_START_PAGE = "https://www.gov.uk/make-a-plea"

--- a/make_a_plea/urls.py
+++ b/make_a_plea/urls.py
@@ -9,7 +9,6 @@ from django.contrib import admin
 from django.views.generic import TemplateView
 from apps.plea.views import CourtFinderView
 
-
 admin.autodiscover()
 
 
@@ -17,7 +16,7 @@ handler500 = "make_a_plea.views.server_error"
 
 urlpatterns = patterns(
     "",
-    url(r"^$", TemplateView.as_view(template_name="start.html"), name="home"),
+    url(r"^$", views.start, name="home"),
     url(r"^helping-you-plead-online/$", views.TranslatedView.as_view(template_name="ad_support.html"), name="ad_support"),
     url(r"^terms-and-conditions-and-privacy-policy/$", views.TranslatedView.as_view(template_name="terms.html"), name="terms"),
     url(r"^plea/", include("apps.plea.urls", )),

--- a/make_a_plea/views.py
+++ b/make_a_plea/views.py
@@ -9,6 +9,12 @@ from django.views.generic import TemplateView
 
 from waffle.decorators import waffle_switch
 
+def start(request):
+    if hasattr(settings, "REDIRECT_START_PAGE"):
+        return http.HttpResponseRedirect(settings.REDIRECT_START_PAGE)
+
+    return render(request, "start.html")
+
 
 class TranslatedView(TemplateView):
     """


### PR DESCRIPTION
As it stood, a successfull feedback submission would produce a success
flash message on the redirect screen. This was a problem when the
redirect screen was the start screen, as this is now hosted on gov.uk.

To avoid this issue, submitting feedback now results in a standalone
confiramtion screen. This screen shows a Finish button which takes the
user back to where they were when they started giving feedback.

[MAPDEV497]