### PR TITLE
Fix validation error bug on non-required field

### DIFF
--- a/apps/forms/forms.py
+++ b/apps/forms/forms.py
@@ -69,6 +69,13 @@ class BaseStageForm(forms.Form):
                     if self.split_form is None or self.split_form != dependency_field:
                         self.fields[field].required = test_dependency_match(dependency_field, dependency_value)
 
+                        # If the field is not required anymore, remove its value from the form data to prevent other validation errors
+                        if self.fields[field].required == False:
+                            try:
+                                del self.data[field]
+                            except KeyError:
+                                pass
+
 
 class SplitStageForm(BaseStageForm):
     split_form = forms.CharField(widget=forms.HiddenInput(), required=False)


### PR DESCRIPTION
Fields that are only required when another field is set to a certain
value were still erroring on other validation issues. This update
removes the field value form the form data if it is not required
anymore, to prevent such other validation errors.

As a bonus side-effect, this update also helps pruning data that isn't necessary form the session.

[MAPDEV543]