### PR TITLE
Added a run.sh for docker that handles a DOCKER_STATE env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN gpg --import /makeaplea/docker/user_data.gpg
 RUN python manage.py collectstatic --noinput
 RUN python manage.py compilemessages
 
-CMD ["gunicorn",  "make_a_plea.wsgi", "--bind=0.0.0.0:9080"]
+CMD ["./run.sh"]
 
 EXPOSE 9080
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+case ${DOCKER_STATE} in
+migrate)
+    echo "running migrate"
+    ./manage.py migrate
+    ;;
+esac
+
+gunicorn make_a_plea.wsgi --bind=0.0.0.0:9080
+


### PR DESCRIPTION
Added a run.sh file that handles a DOCKER_STATE var, so that the parameterised build job in Jenkins can run various django commands.  Currently we're only handling a database migration.

