### PR TITLE
Amend home page redirect so that it works with TD setup

### DIFF
--- a/make_a_plea/settings/docker.py
+++ b/make_a_plea/settings/docker.py
@@ -55,3 +55,5 @@ ENCRYPTED_COOKIE_KEYS = [
 ]
 
 STORE_USER_DATA = os.environ.get("STORE_USER_DATA", "") == "True"
+
+REDIRECT_START_PAGE = os.environ.get("REDIRECT_START_PAGE", "")

--- a/make_a_plea/views.py
+++ b/make_a_plea/views.py
@@ -9,8 +9,9 @@ from django.views.generic import TemplateView
 
 from waffle.decorators import waffle_switch
 
+
 def start(request):
-    if hasattr(settings, "REDIRECT_START_PAGE"):
+    if getattr(settings, "REDIRECT_START_PAGE", ""):
         return http.HttpResponseRedirect(settings.REDIRECT_START_PAGE)
 
     return render(request, "start.html")


### PR DESCRIPTION
Minor amend to make REDIRECT_START_PAGE work with template-deploy and the single settings file (docker.py).

I think going forward it'd be easier if we do split up the settings files so we have the usual settings/staging.py, settings.prod.py etc. But for now this should work.
