### PR TITLE
Fix to prevent offence data from showing if the user does not auth

### DIFF
--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -384,9 +384,14 @@ class PleaStage(IndexedStage):
             pass
 
     def load_forms(self, data=None, initial=False):
+
         initial_data = None
-        # TODO: change this to grabbing by case OU or a FK at some point
-        offences = get_offences(self.all_data["case"])
+
+        # Only show offence data for DX cases
+        if self.all_data.get("dx", False):
+            offences = get_offences(self.all_data["case"])
+        else:
+            offences = False
 
         if initial:
             data = self.all_data.get(self.name, {}).get("data", [])

--- a/apps/plea/tests/test_stages_data.py
+++ b/apps/plea/tests/test_stages_data.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
 from django.test import TestCase
 
-from ..stages import URNEntryStage, AuthenticationStage
-from ..models import Court, Case
+from ..stages import URNEntryStage, AuthenticationStage, PleaStage
+from ..models import Court, Case, Offence
 
 
 class TestURNStageDataBase(TestCase):
@@ -546,5 +546,31 @@ class TestCompanyAuthStageBoth(TestURNStageDataBase):
         stage.save({"postcode": "m601pr", "number_of_charges": 2})
         self.assertEqual(stage.next_step, "company_details")
         self.assertEqual(self.data2["notice_type"]["sjp"], False)
+
+
+class TestPleaAuthStage(TestURNStageDataBase):
+    def test_offences_shown_with_dx(self):
+
+        self.data["dx"] = True
+        self.data["plea"] = {}
+        self.data["case"]["urn"] = "06AA0000015"
+
+        stage = PleaStage(self.urls, self.data)
+        stage.load_forms({})
+
+        self.assertIsInstance(stage.form.case_data, Offence)
+
+    def test_offences_not_shown_with_no_dx(self):
+
+        self.data["dx"] = False
+        self.data["plea"] = {}
+
+        stage = PleaStage(self.urls, self.data)
+        stage.load_forms({})
+
+        self.assertFalse(getattr(stage.form, "case_data", False))
+
+
+
 
 


### PR DESCRIPTION
Quick fix to prevent offence data from showing if the user does not auth or if DX is not enabled.