### PR TITLE
Added timestamp field which is visible in the admin

### DIFF
--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -82,6 +82,7 @@ class CaseAdmin(admin.ModelAdmin):
     list_filter = ("sent", "processed", "initiation_type", "ou_code", "imported")
     inlines = [InlineCaseAction, InlineOffence]
     search_fields = ["urn", "case_number"]
+    readonly_fields = ('created',)
 
     def charge_count(self, obj):
         return obj.offences.count()

--- a/apps/plea/migrations/0031_case_created.py
+++ b/apps/plea/migrations/0031_case_created.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0030_auto_20160222_1434'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='case',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -251,6 +251,7 @@ class Case(models.Model):
     User data is gpg encrypted and persisted to disc then
     transferred to an encrypted S3 account.
     """
+    created = models.DateTimeField(auto_now_add=True, null=True, blank=True)
 
     urn = models.CharField(max_length=30, db_index=True)
 

--- a/apps/result/admin.py
+++ b/apps/result/admin.py
@@ -23,6 +23,7 @@ class ResultAdmin(nested_admin.NestedModelAdmin):
     list_filter = ("ou_code", "sent", )
     inlines = [InlineResultOffence, ]
     search_fields = ["urn", "case_number"]
+    readonly_fields = ('created',)
 
 
 admin.site.register(Result, ResultAdmin)

--- a/apps/result/migrations/0003_result_created.py
+++ b/apps/result/migrations/0003_result_created.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('result', '0002_auto_20160225_1621'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='result',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+    ]

--- a/apps/result/models.py
+++ b/apps/result/models.py
@@ -43,6 +43,8 @@ WITHDRAWN_CODES = {
 
 
 class Result(models.Model):
+    created = models.DateTimeField(auto_now_add=True, null=True, blank=True)
+
     case = models.ForeignKey("plea.Case", related_name="results", null=True, blank=True)
     urn = models.CharField(max_length=30, db_index=True)
 


### PR DESCRIPTION
Amends and migrations added to add the time stamp field to the Result and Case models, and to add a read-only copy of the field to the admin.

This will aid in data investigation when we need to determine when a record was created to try to locate it in the source DX files.