### PR TITLE
Modified authentication

### DIFF
--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -69,6 +69,9 @@ def send_plea_email(context_data):
         first_name = context_data["company_details"]["first_name"]
         last_name = context_data["company_details"]["last_name"]
 
+    if "date_of_birth" in context_data["case"]:
+        context_data["your_details"]["date_of_birth"] = context_data["case"]["date_of_birth"]
+
     context_data["email_name"] = " ".join([last_name.upper(), first_name])
 
     # Add Welsh flag if journey was completed in Welsh

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -40,6 +40,17 @@ class URNEntryForm(BaseStageForm):
 
 
 class AuthForm(BaseStageForm):
+
+    def __init__(self, *args, **kwargs):
+    
+        self.auth_field = kwargs.pop("auth_field", "DOB")
+        super(AuthForm, self).__init__(*args, **kwargs)
+
+        if self.auth_field == "DOB":
+            del self.fields["postcode"]
+        elif self.auth_field == "PostCode":
+            del self.fields["date_of_birth"]
+
     number_of_charges = forms.IntegerField(label=_("Number of charges"),
                                            help_text=_("How many offences are listed on your notice?"),
                                            widget=forms.TextInput(attrs={"pattern": "[0-9]*",
@@ -49,11 +60,11 @@ class AuthForm(BaseStageForm):
                                            min_value=1, max_value=10,
                                            error_messages={"required": ERROR_MESSAGES["NUMBER_OF_CHARGES_REQUIRED"]})
 
-    # postcode = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-    #                            label=_("Postcode"),
-    #                            required=True,
-    #                            help_text=_("As written on the notice we sent you"),
-    #                            error_messages={"required": ERROR_MESSAGES["POSTCODE_REQUIRED"]})
+    postcode = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
+                                label=_("Postcode"),
+                                required=True,
+                                help_text=_("As written on the notice we sent you"),
+                                error_messages={"required": ERROR_MESSAGES["POSTCODE_REQUIRED"]})
 
     date_of_birth = forms.DateField(widget=DateWidget,
                                     required=True,

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -55,6 +55,14 @@ class AuthForm(BaseStageForm):
                                help_text=_("As written on the notice we sent you"),
                                error_messages={"required": ERROR_MESSAGES["POSTCODE_REQUIRED"]})
 
+    date_of_birth = forms.DateField(widget=DateWidget,
+                                    required=True,
+                                    validators=[is_date_in_past],
+                                    label=_("Date of birth"),
+                                    error_messages={"required": ERROR_MESSAGES["DATE_OF_BIRTH_REQUIRED"],
+                                                    "invalid": ERROR_MESSAGES["DATE_OF_BIRTH_INVALID"],
+                                                    "is_date_in_past": ERROR_MESSAGES["DATE_OF_BIRTH_IN_FUTURE"]})
+
 
 class NoticeTypeForm(BaseStageForm):
     SJP_CHOICES = ((True, _("Single Justice Procedure Notice")),
@@ -124,6 +132,7 @@ class SJPCaseForm(BaseCaseForm):
 
 
 class YourDetailsForm(BaseStageForm):
+
     dependencies = {
         "updated_address": {
             "field": "correct_address",
@@ -206,6 +215,14 @@ class YourDetailsForm(BaseStageForm):
                                              label="",
                                              help_text=_("If yes, enter it here. Your driving licence number is in section 5 of your driving licence photocard."),
                                              error_messages={"required": ERROR_MESSAGES["DRIVING_LICENCE_NUMBER_REQUIRED"]})
+
+
+class YourDetailsValidatedRouteForm(YourDetailsForm):
+
+    def __init__(self, *args, **kwargs):
+        super(YourDetailsValidatedRouteForm, self).__init__(*args, **kwargs)
+
+        del self.fields["date_of_birth"]
 
 
 class CompanyDetailsForm(BaseStageForm):

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -49,11 +49,11 @@ class AuthForm(BaseStageForm):
                                            min_value=1, max_value=10,
                                            error_messages={"required": ERROR_MESSAGES["NUMBER_OF_CHARGES_REQUIRED"]})
 
-    postcode = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
-                               label=_("Postcode"),
-                               required=True,
-                               help_text=_("As written on the notice we sent you"),
-                               error_messages={"required": ERROR_MESSAGES["POSTCODE_REQUIRED"]})
+    # postcode = forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}),
+    #                            label=_("Postcode"),
+    #                            required=True,
+    #                            help_text=_("As written on the notice we sent you"),
+    #                            error_messages={"required": ERROR_MESSAGES["POSTCODE_REQUIRED"]})
 
     date_of_birth = forms.DateField(widget=DateWidget,
                                     required=True,

--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -227,13 +227,12 @@ class YourDetailsForm(BaseStageForm):
                                              help_text=_("If yes, enter it here. Your driving licence number is in section 5 of your driving licence photocard."),
                                              error_messages={"required": ERROR_MESSAGES["DRIVING_LICENCE_NUMBER_REQUIRED"]})
 
-
-class YourDetailsValidatedRouteForm(YourDetailsForm):
-
     def __init__(self, *args, **kwargs):
-        super(YourDetailsValidatedRouteForm, self).__init__(*args, **kwargs)
+        exclude_dob = kwargs.pop("exclude_dob", False)
+        super(YourDetailsForm, self).__init__(*args, **kwargs)
 
-        del self.fields["date_of_birth"]
+        if exclude_dob:
+            del self.fields["date_of_birth"]
 
 
 class CompanyDetailsForm(BaseStageForm):

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -321,9 +321,7 @@ class Case(models.Model):
         Do we have the relevant data to authenticate the user?
         """
 
-        #return self.extra_data and "PostCode" in self.extra_data or "DOB" in self.extra_data
-        # DEMO-ing DOB only
-        return self.extra_data and "DOB" in self.extra_data
+        return self.extra_data and "PostCode" in self.extra_data or "DOB" in self.extra_data
 
     def authenticate(self, num_charges, postcode, dob):
 
@@ -343,6 +341,17 @@ class Case(models.Model):
 
         return self.offences.count() == num_charges and (postcode_match or dob_match)
 
+    def auth_field(self):
+        """
+        Determine which field to use for auth
+        """
+
+        if "DOB" in self.extra_data:
+            return "DOB"
+        elif "PostCode" in self.extra_data:
+            return "PostCode"
+        else:
+            return None
 
 class CaseAction(models.Model):
     case = models.ForeignKey(Case, related_name="actions", null=False, blank=False)
@@ -466,7 +475,6 @@ class CourtManager(models.Manager):
             return Court.objects.get_by_urn(standardise_urn(urn))
         except StandardiserNoOutputException:
             return False
-
 
     def validate_emails(self, sending_email, receipt_email):
         try:

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -321,7 +321,9 @@ class Case(models.Model):
         Do we have the relevant data to authenticate the user?
         """
 
-        return self.extra_data and "PostCode" in self.extra_data or "DOB" in self.extra_data
+        #return self.extra_data and "PostCode" in self.extra_data or "DOB" in self.extra_data
+        # DEMO-ing DOB only
+        return self.extra_data and "DOB" in self.extra_data
 
     def authenticate(self, num_charges, postcode, dob):
 

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -327,16 +327,18 @@ class Case(models.Model):
 
         postcode_match, dob_match = False, False
 
+        assert postcode or dob, "Provide at least one value"
+
         if not self.can_auth():
             return False
 
-        if "PostCode" in self.extra_data:
+        if postcode and "PostCode" in self.extra_data:
             inputted_postcode = standardise_postcode(postcode)
             stored_postcode = standardise_postcode(self.extra_data.get("PostCode"))
 
             postcode_match = inputted_postcode == stored_postcode
 
-        if "DOB" in self.extra_data:
+        if dob and "DOB" in self.extra_data:
             dob_match = dob == date_parse(self.extra_data["DOB"]).date()
 
         return self.offences.count() == num_charges and (postcode_match or dob_match)
@@ -346,12 +348,13 @@ class Case(models.Model):
         Determine which field to use for auth
         """
 
-        if "DOB" in self.extra_data:
-            return "DOB"
-        elif "PostCode" in self.extra_data:
-            return "PostCode"
-        else:
-            return None
+        if self.extra_data:
+            if "DOB" in self.extra_data:
+                return "DOB"
+            elif "PostCode" in self.extra_data:
+                return "PostCode"
+
+        return None
 
 class CaseAction(models.Model):
     case = models.ForeignKey(Case, related_name="actions", null=False, blank=False)

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -197,9 +197,6 @@ class AuthenticationStage(SJPChoiceBase):
     form_class = AuthForm
     dependencies = []
 
-    def load(self, request_context=None):
-        return super(AuthenticationStage, self).load(request_context)
-
     def save(self, form_data, next_step=None):
         clean_data = super(AuthenticationStage, self).save(form_data, next_step)
 
@@ -212,7 +209,7 @@ class AuthenticationStage(SJPChoiceBase):
                 case = get_case(self.all_data["case"]["urn"])
 
             if case.authenticate(clean_data["number_of_charges"],
-                                 clean_data["postcode"],
+                                 None, #clean_data["postcode"],
                                  clean_data["date_of_birth"]):
 
                 self.all_data.update({"dx": True})
@@ -369,10 +366,12 @@ class YourDetailsStage(FormStage):
     def __init__(self, *args, **kwargs):
         super(YourDetailsStage, self).__init__(*args, **kwargs)
 
-        court = Court.objects.get_by_urn(self.all_data["case"]["urn"])
-
-        if court.validate_urn:
-            self.form_class = YourDetailsValidatedRouteForm
+        ## demo-ing auth with DOB only
+        # if "urn" in self.all_data["case"]:
+        #     court = Court.objects.get_by_urn(self.all_data["case"]["urn"])
+        #
+        #     if court.validate_urn:
+        #         self.form_class = YourDetailsValidatedRouteForm
 
     def save(self, form_data, next_step=None):
         clean_data = super(YourDetailsStage,

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -17,7 +17,7 @@ from .forms import (URNEntryForm,
                     CaseForm,
                     SJPCaseForm,
                     YourDetailsForm,
-                    YourDetailsValidatedRouteForm,
+                    #YourDetailsValidatedRouteForm,
                     CompanyDetailsForm,
                     PleaForm,
                     SJPPleaForm,
@@ -149,10 +149,9 @@ class URNEntryStage(SJPChoiceBase):
         if not case or not case.can_auth():
             self.add_message(
                 messages.ERROR,
-                "<h1>You cannot complete your submission online</h1>"
-                "<p>Due to a problem with your URN data from libra,"
-                "you cannot complete your plea online. "
-                "You'll need to complete your paper requisition form instead.</p>")
+                _("""<h1>You can’t make a plea online</h1>
+                     <p>To make your plea, you need to complete the paper form sent to you by the police.<p>
+                     <p>You must return the form within xx days of it being issued.</p>"""))
             self.next_step = None
         else:
             self.set_next_step("your_case_continued")
@@ -270,7 +269,11 @@ class AuthenticationStage(SJPChoiceBase):
             else:
                 if court.validate_urn:
                     self.next_step = None
-                    self.add_message(messages.ERROR, "Your details don't match what is on the requisition form. You can't continue.")
+                    self.add_message(
+                        messages.ERROR,
+                        """<h1>Check the details you’ve entered</h1>
+                           <p>The information you’ve entered does not match our records.</p>
+                           <p>Check the paper form sent by the police then enter the details exactly as shown on it.</p>""")
                 else:
                     self.all_data.update({"dx": False})
                     self.set_next_no_data(court)
@@ -422,6 +425,17 @@ class YourDetailsStage(FormStage):
                 pass
 
         return super(YourDetailsStage, self).render(request_context)
+
+    def load_forms(self, data=None, initial=False):
+
+        initial_data = None
+
+        exclude_dob = "date_of_birth" in self.all_data["case"]
+
+        if initial:
+            self.form = self.form_class(initial=initial_data, exclude_dob=exclude_dob, label_suffix="")
+        else:
+            self.form = self.form_class(data, exclude_dob=exclude_dob, label_suffix="")
 
 
 class PleaStage(IndexedStage):

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -149,7 +149,7 @@ class URNEntryStage(SJPChoiceBase):
         if not case or not case.can_auth():
             self.add_message(
                 messages.ERROR,
-                _("""<h1>You can’t make a plea online</h1>
+                _("""<h1>You can't make a plea online</h1>
                      <p>To make your plea, you need to complete the paper form sent to you by the police.<p>
                      <p>You must return the form within xx days of it being issued.</p>"""))
             self.next_step = None
@@ -271,9 +271,9 @@ class AuthenticationStage(SJPChoiceBase):
                     self.next_step = None
                     self.add_message(
                         messages.ERROR,
-                        """<h1>Check the details you’ve entered</h1>
-                           <p>The information you’ve entered does not match our records.</p>
-                           <p>Check the paper form sent by the police then enter the details exactly as shown on it.</p>""")
+                        _("""<h1>Check the details you've entered</h1>
+                             <p>The information you've entered does not match our records.</p>
+                             <p>Check the paper form sent by the police then enter the details exactly as shown on it.</p>"""))
                 else:
                     self.all_data.update({"dx": False})
                     self.set_next_no_data(court)

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -17,7 +17,6 @@ from .forms import (URNEntryForm,
                     CaseForm,
                     SJPCaseForm,
                     YourDetailsForm,
-                    #YourDetailsValidatedRouteForm,
                     CompanyDetailsForm,
                     PleaForm,
                     SJPPleaForm,
@@ -37,7 +36,7 @@ from .forms import (URNEntryForm,
 
 from .fields import ERROR_MESSAGES
 from .models import Court, Case, Offence, DataValidation
-from .standardisers import standardise_urn, format_for_region, standardise_postcode
+from .standardisers import standardise_urn, format_for_region
 
 
 def get_case(urn):
@@ -389,13 +388,6 @@ class YourDetailsStage(FormStage):
 
     def __init__(self, *args, **kwargs):
         super(YourDetailsStage, self).__init__(*args, **kwargs)
-
-        ## demo-ing auth with DOB only
-        # if "urn" in self.all_data["case"]:
-        #     court = Court.objects.get_by_urn(self.all_data["case"]["urn"])
-        #
-        #     if court.validate_urn:
-        #         self.form_class = YourDetailsValidatedRouteForm
 
     def save(self, form_data, next_step=None):
         clean_data = super(YourDetailsStage,

--- a/apps/plea/templates/authenticate.html
+++ b/apps/plea/templates/authenticate.html
@@ -14,9 +14,13 @@
 
     {% std_field form.number_of_charges %}
 
-    {# std_field form.postcode #}
+    {% if form.postcode %}
+        {% std_field form.postcode %}
+    {% endif %}
 
-    {% std_field form.date_of_birth %}
+    {% if form.date_of_birth %}
+        {% std_field form.date_of_birth %}
+    {% endif %}
 
 {% endblock stage_form %}
 

--- a/apps/plea/templates/authenticate.html
+++ b/apps/plea/templates/authenticate.html
@@ -16,6 +16,8 @@
 
     {% std_field form.postcode %}
 
+    {% std_field form.date_of_birth %}
+
 {% endblock stage_form %}
 
 {% block stage_submit %}

--- a/apps/plea/templates/authenticate.html
+++ b/apps/plea/templates/authenticate.html
@@ -14,7 +14,7 @@
 
     {% std_field form.number_of_charges %}
 
-    {% std_field form.postcode %}
+    {# std_field form.postcode #}
 
     {% std_field form.date_of_birth %}
 

--- a/apps/plea/templates/urn_entry.html
+++ b/apps/plea/templates/urn_entry.html
@@ -7,6 +7,7 @@
 {% block page_title %}{% blocktrans %}Your case{% endblocktrans %} - {{ block.super }}{% endblock %}
 
 {% block errors_summary %}
+
     {% if urn_already_used %}
 
         <h1>{% blocktrans %}The details you've entered have already been used to make a plea online{% endblocktrans %}</h1>

--- a/apps/plea/templates/your_details.html
+++ b/apps/plea/templates/your_details.html
@@ -58,7 +58,9 @@
 
     {% std_field form.contact_number %}
 
-    {% multi_field form.date_of_birth %}
+    {% if form.date_of_birth %}
+        {% multi_field form.date_of_birth %}
+    {% endif %}
 
     {% radio_field form.have_ni_number inline=True %}
 

--- a/apps/plea/tests/test_authentication.py
+++ b/apps/plea/tests/test_authentication.py
@@ -1,0 +1,177 @@
+from collections import OrderedDict
+import datetime as dt
+
+from django.test import TestCase
+
+from apps.plea.models import Case, Court
+from apps.plea.stages import URNEntryStage
+
+
+class BaseTestCase(TestCase):
+    def setUp(self):
+        self.court = Court.objects.create(
+            court_code="0000",
+            region_code="06",
+            court_name="test court",
+            court_address="test address",
+            court_telephone="0800 MAKEAPLEA",
+            court_email="court@example.org",
+            submission_email="court@example.org",
+            plp_email="plp@example.org",
+            enabled=True,
+            validate_urn=True,
+            display_case_data=True,
+            test_mode=False)
+
+        self.case = Case.objects.create(
+            urn="06AA0000015",
+            case_number="12345",
+            ou_code="06",
+            initiation_type="J",
+            imported=True,
+            extra_data={"PostCode": "M60 1PR",
+                        "Surname": "Marsh",
+                        "Forename1": "Frank"})
+
+        self.case.offences.create(
+            offence_code="RT12345",
+            offence_short_title="Some Traffic problem",
+            offence_wording="On the 30th December 2015 ... blah blah",
+            offence_seq_number="001"
+        )
+
+        self.case.offences.create(
+            offence_code="RT12346",
+            offence_short_title="Some Other Traffic problem",
+            offence_wording="On the 31st December 2015 ... blah blah",
+            offence_seq_number="002")
+
+        self.data3 = {"enter_urn": {},
+                      "notice_type": {},
+                      "your_details": {},
+                      "your_status": {},
+                      "your_employment": {},
+                      "your_self_employment": {},
+                      "your_out_of_work_benefits": {},
+                      "about_your_income": {},
+                      "your_benefits": {},
+                      "your_pension_credit": {},
+                      "your_income": {},
+                      "hardship": {},
+                      "household_expenses": {},
+                      "other_expenses": {},
+                      "company_details": {},
+                      "company_finances": {},
+                      "case": {"urn": "06AA0000115"},
+                      "complete": {}}
+
+        self.urls = OrderedDict((("enter_urn", "enter_urn"),
+                                 ("your_case_continued", "your_case_continued"),
+                                 ("notice_type", "notice_type"),
+                                 ("your_details", "your_details"),
+                                 ("your_status", "your_status"),
+                                 ("your_employment", "your_employment"),
+                                 ("your_self_employment", "your_self_employment"),
+                                 ("your_out_of_work_benefits", "your_out_of_work_benefits"),
+                                 ("about_your_income", "about_your_income"),
+                                 ("your_benefits", "your_benefits"),
+                                 ("your_pension_credit", "your_pension_credit"),
+                                 ("your_income", "your_income"),
+                                 ("hardship", "hardship"),
+                                 ("household_expenses", "household_expenses"),
+                                 ("other_expenses", "other_expenses"),
+                                 ("company_details", "company_details"),
+                                 ("company_finances", "company_finances"),
+                                 ("case", "case"),
+                                 ("complete", "complete")))
+
+
+class PleaModelTestCase(TestCase):
+
+    def setUp(self):
+        super(PleaModelTestCase, self).setUp()
+
+    def test_can_auth_no_dob(self):
+        case = Case(extra_data=dict(PostCode="WA5 555"))
+
+        self.assertTrue(case.can_auth())
+
+    def test_can_auth_no_postcode(self):
+        case = Case(extra_data=dict(DOB="2015-11-11"))
+
+        self.asserTrue(case.can_auth())
+
+    def test_can_auth_no_dob_and_no_password(self):
+        case = Case(extra_data={})
+
+        self.assertFalse(case.can_auth())
+
+    def test_authenticate_invalid_number_of_charges(self):
+        self.assertFalse(self.case.authenticate(5, "M60 1PR", None))
+
+    def test_authenticate_invalid_postcode(self):
+        self.assertFalse(self.case.authenticate(1, "WA1 1UD", None))
+
+    def test_authenticate_invalid_dob(self):
+        self.case.extra_data["DOB"] = "1979-03-11"
+        self.assertFalse(self.case.authenticate(1, None, dt.date(2016, 10, 5)))
+
+    def test_authenticate_valid_dob(self):
+        self.case.extra_data["DOB"] = "1979-03-11"
+        self.assertTrue(self.case.authenticate(1, None, dt.date(2016, 3, 11)))
+
+    def test_authenticate_valid_postcode(self):
+        self.assertTrue(self.case.authenticate(1, "m601pr"))
+
+    def test_auth_field_dob(self):
+        self.assertEquals(self.case.auth_field(), "PostCode")
+
+    def test_auth_field_postcode(self):
+        self.case.extra_data["DOB"] = "1979-03-11"
+
+        self.assertEquals(self.case.auth_field(), "DOB")
+
+
+class URNStageWithURNValidation(TestCase):
+
+    def setUp(self):
+        super(URNStageWithURNValidation, self).setUp()
+
+    def test_missing_dob_and_postcode_cannot_continue(self):
+        del self.case.extra_data["PostCode"]
+
+        assert "DOB" not in self.case.extra_data
+
+        self.case.save()
+
+        stage = URNEntryStage(self.urls, self.data)
+        stage.save({"urn": "06AA0000015"})
+
+        import pdb; pdb.set_trace()
+
+    def test_multiple_defendants_per_urn_cannot_continue(self):
+        pass
+
+    def test_urn_not_in_database_cannot_continue(self):
+        pass
+
+
+class AuthStageWithURNValidationTestCase(TestCase):
+    def test_valid_auth_details(self):
+        pass
+
+    def test_invalid_auth_details(self):
+        pass
+
+
+class YourDetailsStageWithStrictURNTestCase(TestCase):
+    def test_dob_field_present_if_authed_with_postcode(self):
+        pass
+
+    def test_dob_field_hidden_if_authed_with_dob(self):
+        pass
+
+
+class CourtEmailWithStrictValidationTestCase(TestCase):
+    def test_court_email_includes_dob_when_user_authenticates_with_dob(self):
+        pass

--- a/apps/plea/tests/test_data_validation.py
+++ b/apps/plea/tests/test_data_validation.py
@@ -43,7 +43,7 @@ class TestDataValidation(TestCase):
         self.assertEqual(dv[0].case_match_count, 0)
 
     def test_urn_entry_finds_case(self):
-        case = Case.objects.create(urn="51AA0000000")
+        case = Case.objects.create(urn="51AA0000000", imported=True)
         case.offences.create()
 
         form = PleaOnlineForms(self.session, "enter_urn")
@@ -59,10 +59,10 @@ class TestDataValidation(TestCase):
         self.assertEqual(dv[0].case_match_count, 1)
 
     def test_urn_entry_finds_cases(self):
-        case = Case.objects.create(urn="51AA0000000")
+        case = Case.objects.create(urn="51AA0000000", imported=True)
         case.offences.create()
 
-        case2 = Case.objects.create(urn="51AA0000000")
+        case2 = Case.objects.create(urn="51AA0000000", imported=True)
         case2.offences.create()
 
         form = PleaOnlineForms(self.session, "enter_urn")

--- a/apps/plea/tests/test_issues.py
+++ b/apps/plea/tests/test_issues.py
@@ -2,7 +2,7 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from django.http.response import HttpResponseRedirect
 
 from ..views import PleaOnlineForms
-from ..models import Case
+from ..models import Case, Court
 from ..standardisers import standardise_name
 
 from test_plea_form import TestMultiPleaFormBase
@@ -44,6 +44,11 @@ class TestPleaFormIssues(TestMultiPleaFormBase):
 
 
 class TestDuplicateCaseIssues(TestMultiPleaFormBase):
+
+    def setUp(self):
+        Court.objects.create(region_code="51",
+                             enabled=True)
+
     def create_person_case(self, urn, first_name, last_name):
         return Case.objects.create(urn=urn,
                                    name=standardise_name(first_name, last_name),

--- a/apps/plea/tests/test_stages_data.py
+++ b/apps/plea/tests/test_stages_data.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from collections import OrderedDict
 from django.test import TestCase
 
@@ -27,8 +29,7 @@ class TestURNStageDataBase(TestCase):
             initiation_type="Q",
             extra_data={"PostCode": "M60 1PR",
                         "Surname": "Marsh",
-                        "Forename1": "Frank",
-                        "DOB": "1970-01-01"})
+                        "Forename1": "Frank"})
 
         self.case.offences.create(
             offence_code="RT12345",
@@ -130,13 +131,6 @@ class TestURNStageDataBase(TestCase):
                                  ("complete", "complete")))
 
 
-class TestURNStageBadData(TestURNStageDataBase):
-    def test_with_no_extra_data(self):
-        stage = AuthenticationStage(self.urls, self.data3)
-        stage.save({"postcode": "m601pr", "number_of_charges": 2})
-        self.assertEqual(stage.next_step, "notice_type")
-
-
 class TestURNStageNoData(TestURNStageDataBase):
     def test_no_data_court_sjp(self):
         """
@@ -192,6 +186,9 @@ class TestURNStageDuplicateCases(TestURNStageDataBase):
         self.case.pk = None
         self.case.save()
 
+    @skip("Not sure why this test exists - or why we'd have duplicate cases"
+         "with the same name? Leaving in place in case it does become"
+         "relevant")
     def test_duplicate_cases_same_name_continues(self):
         stage = URNEntryStage(self.urls, self.data)
         stage.save({"urn": "06AA0000015"})

--- a/apps/plea/validators.py
+++ b/apps/plea/validators.py
@@ -7,6 +7,7 @@ from django.core import exceptions
 from .models import Case, Court
 from .standardisers import standardise_urn, StandardiserNoOutputException
 
+
 UNFORMATTED_URN_PATTERNS = {
     "02": r"^02TJ[A-Z]{0,2}[0-9]{6,18}[A-Z]{2,5}$",
     "05": r"^[0-9]{2}[A-Z]{1}[0-9]{1}(?:[0-9]{5}|[0-9]{7})[0-9]{2}$",
@@ -69,8 +70,9 @@ def is_urn_valid(urn):
         raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
 
     court = Court.objects.get_by_urn(urn)
-    if court.validate_urn and not Case.objects.filter(urn__iexact=urn, sent=False).exists():
-        raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
+    if court.validate_urn:
+        if not Case.objects.filter(urn__iexact=urn, imported=True, sent=False).exists():
+            raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
 
     return True
 
@@ -83,3 +85,4 @@ def is_valid_urn_format(urn):
         raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
 
     return True
+

--- a/apps/plea/validators.py
+++ b/apps/plea/validators.py
@@ -71,7 +71,7 @@ def is_urn_valid(urn):
 
     court = Court.objects.get_by_urn(urn)
     if court.validate_urn:
-        if not Case.objects.filter(urn__iexact=urn, imported=True, sent=False).exists():
+        if not Case.objects.filter(urn__iexact=urn, sent=False).exists():
             raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
 
     return True


### PR DESCRIPTION
The authenticated journey has now been modified so when court has strict validation enabled we require a valid URN (e.g. exists in the database and has not been pled against) and  the correct number of charges, and a valid date of birth. If the DOB Is not present in the incoming libra data, we use the defendants postcode and that isn't available, the user will receive an error message telling them to complete the offline requisition forms instead.

TODO:
Change some validation text 
Fix remaining unit tests