### PR TITLE
Oucode court selection

### DIFF
--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -12,7 +12,8 @@ from apps.plea.models import (UsageStats, Court,
                               CaseOffenceFilter,
                               CourtEmailCount,
                               Offence,
-                              DataValidation)
+                              DataValidation,
+                              OUCode)
 
 
 class RegionalFilter(admin.SimpleListFilter):
@@ -61,9 +62,20 @@ class UsageStatsAdmin(admin.ModelAdmin):
     list_editable = ('postal_requisitions', 'postal_responses')
 
 
+class InlineOUCode(admin.StackedInline):
+    model = OUCode
+    extra = 1
+
+
 class CourtAdmin(admin.ModelAdmin):
-    list_display = ('court_name', 'region_code', 'court_address', 'court_email', 'plp_email',
+    list_display = ('court_name', 'region_code', 'court_address', 'court_email', 'plp_email', 'ou_codes',
                     'enabled', 'test_mode', 'notice_types', 'validate_urn', 'display_case_data')
+
+    inlines = (InlineOUCode,)
+
+    def ou_codes(self, obj):
+
+        return ", ".join(x.ou_code for x in obj.oucode_set.all())
 
 
 class InlineCaseAction(admin.TabularInline):

--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -44,11 +44,11 @@ def send_plea_email(context_data):
     context_data: dict populated by form fields
     """
 
-    try:
-        case = Case.objects.get(
-            urn__iexact=context_data["case"]["urn"].upper(), sent=False)
+    case = Case.objects.filter(
+        urn__iexact=context_data["case"]["urn"].upper(), sent=False,
+        imported=True).first()
 
-    except (Case.DoesNotExist, Case.MultipleObjectsReturned):
+    if not case:
         case = Case.objects.create(urn=context_data["case"]["urn"].upper(),
                                    sent=False,
                                    imported=False)

--- a/apps/plea/email.py
+++ b/apps/plea/email.py
@@ -44,12 +44,14 @@ def send_plea_email(context_data):
     context_data: dict populated by form fields
     """
 
-    # Get or create case
-    cases = Case.objects.filter(urn__iexact=context_data["case"]["urn"].upper(), sent=False)
-    if len(cases) == 0:
-        case = Case(urn=context_data["case"]["urn"].upper(), sent=False)
-    else:
-        case = cases[0]
+    try:
+        case = Case.objects.get(
+            urn__iexact=context_data["case"]["urn"].upper(), sent=False)
+
+    except (Case.DoesNotExist, Case.MultipleObjectsReturned):
+        case = Case.objects.create(urn=context_data["case"]["urn"].upper(),
+                                   sent=False,
+                                   imported=False)
 
     court_obj = Court.objects.get_court(context_data["case"]["urn"], ou_code=case.ou_code)
 

--- a/apps/plea/migrations/0033_auto_20160505_1421.py
+++ b/apps/plea/migrations/0033_auto_20160505_1421.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0032_auto_20160420_1121'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='court',
+            name='enforcement_telephone',
+            field=models.CharField(help_text=b'', max_length=255, null=True, verbose_name=b'Telephone number of the enforcement team', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='court',
+            name='region_code',
+            field=models.CharField(help_text=b'The initial two digit URN number, e.g. 06', max_length=2, verbose_name=b'URN Region Code'),
+        ),
+    ]

--- a/apps/plea/migrations/0034_auto_20160519_1047.py
+++ b/apps/plea/migrations/0034_auto_20160519_1047.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0033_auto_20160505_1421'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OUCode',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('ou_code', models.CharField(help_text=b'The first 4 digits of an OU code', unique=True, max_length=4)),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='court',
+            name='ou_code',
+        ),
+        migrations.AddField(
+            model_name='oucode',
+            name='court',
+            field=models.ForeignKey(to='plea.Court'),
+        ),
+    ]

--- a/apps/plea/migrations/0035_auto_20160519_1055.py
+++ b/apps/plea/migrations/0035_auto_20160519_1055.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plea', '0034_auto_20160519_1047'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='oucode',
+            name='ou_code',
+            field=models.CharField(help_text=b'The first five digits of an OU code', unique=True, max_length=5),
+        ),
+    ]

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -483,6 +483,9 @@ class CourtManager(models.Manager):
 
         return self.get_by_urn(urn)
 
+    def get_court_by_ou_code(self, ou_code):
+        return self.select_related().get(oucode__ou_code=ou_code[:4])
+
     def get_court_dx(self, urn):
         """
         Get court whilst using DX data and ou-code matching where possible
@@ -584,8 +587,6 @@ class Court(models.Model):
         help_text="Display the updated plea page for cases that have offence data attached"
     )
 
-    ou_code = models.CharField(max_length=10, null=True, blank=True)
-
     enforcement_email = models.CharField(
         verbose_name="Email address of the enforcement team",
         max_length=255, null=True, blank=True,
@@ -602,6 +603,11 @@ class Court(models.Model):
                                      self.court_name)
 
     objects = CourtManager()
+
+
+class OUCode(models.Model):
+    court = models.ForeignKey(Court)
+    ou_code = models.CharField(max_length=5, unique=True, help_text="The first five digits of an OU code")
 
 
 class DataValidation(models.Model):

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -280,10 +280,14 @@ class Case(models.Model):
     imported = models.BooleanField(default=False)
 
     ou_code = models.CharField(max_length=10, null=True, blank=True)
-    initiation_type = models.CharField(max_length=2, null=False, blank=False, default="Q",
+    initiation_type = models.CharField(max_length=2,
+                                       null=False,
+                                       blank=False,
+                                       default="Q",
                                        choices=INITIATION_TYPE_CHOICES)
-    language = models.CharField(max_length=2, null=False, blank=False, default="en",
-                                choices=COURT_LANGUAGE_CHOICES)
+
+    language = models.CharField(max_length=2, null=False, blank=False,
+                                default="en", choices=COURT_LANGUAGE_CHOICES)
 
     sent = models.BooleanField(null=False, default=False)
     processed = models.BooleanField(null=False, default=False)
@@ -312,7 +316,8 @@ class Case(models.Model):
             return self.name
 
         if self.extra_data and "Forename1" in self.extra_data:
-            return "{} {}".format(self.extra_data["Forename1"], self.extra_data["Surname"])
+            return "{} {}".format(self.extra_data["Forename1"],
+                                  self.extra_data["Surname"])
 
         return ""
 
@@ -321,7 +326,8 @@ class Case(models.Model):
         Do we have the relevant data to authenticate the user?
         """
 
-        return self.extra_data and ("PostCode" in self.extra_data or "DOB" in self.extra_data)
+        return self.extra_data and \
+               ("PostCode" in self.extra_data or "DOB" in self.extra_data)
 
     def authenticate(self, num_charges, postcode, dob):
 
@@ -334,7 +340,8 @@ class Case(models.Model):
 
         if postcode and "PostCode" in self.extra_data:
             inputted_postcode = standardise_postcode(postcode)
-            stored_postcode = standardise_postcode(self.extra_data.get("PostCode"))
+            stored_postcode = standardise_postcode(
+                self.extra_data.get("PostCode"))
 
             postcode_match = inputted_postcode == stored_postcode
 
@@ -472,7 +479,8 @@ class CourtManager(models.Manager):
         """
         Attempt to return the court by URN or ou code.
 
-        Prioritise matching on ou code but if there is no match then attempt to match on URN 
+        Prioritise matching on ou code but if there is no match then
+        attempt to match on URN
         """
 
         if ou_code:
@@ -492,8 +500,13 @@ class CourtManager(models.Manager):
         """
 
         try:
-            ou_code = Case.objects.get(urn=standardise_urn(urn), imported=True, ou_code__isnull=False).ou_code
-        except (Case.DoesNotExist, Case.MultipleObjectsReturned, StandardiserNoOutputException):
+            ou_code = Case.objects.get(urn=standardise_urn(urn),
+                                       imported=True,
+                                       ou_code__isnull=False).ou_code
+
+        except (Case.DoesNotExist,
+                Case.MultipleObjectsReturned,
+                StandardiserNoOutputException):
             ou_code = None
 
         return self.get_court(urn, ou_code=ou_code)
@@ -540,7 +553,10 @@ class Court(models.Model):
         max_length=255,
         help_text="The email address for users to contact the court")
 
-    court_language = models.CharField(max_length=4, null=False, blank=False, default="en",
+    court_language = models.CharField(max_length=4,
+                                      null=False,
+                                      blank=False,
+                                      default="en",
                                       choices=COURT_LANGUAGE_CHOICES)
 
     submission_email = models.CharField(
@@ -607,7 +623,8 @@ class Court(models.Model):
 
 class OUCode(models.Model):
     court = models.ForeignKey(Court)
-    ou_code = models.CharField(max_length=5, unique=True, help_text="The first five digits of an OU code")
+    ou_code = models.CharField(max_length=5, unique=True,
+                               help_text="The first five digits of an OU code")
 
 
 class DataValidation(models.Model):

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -477,8 +477,8 @@ class CourtManager(models.Manager):
 
         if ou_code:
             try:
-                return self.get(ou_code=ou_code, enabled=True)
-            except Court.DoesNotExist:
+                return OUCode.objects.get(ou_code=ou_code[:5]).court
+            except OUCode.DoesNotExist:
                 pass
 
         return self.get_by_urn(urn)

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -321,7 +321,7 @@ class Case(models.Model):
         Do we have the relevant data to authenticate the user?
         """
 
-        return self.extra_data and "PostCode" in self.extra_data or "DOB" in self.extra_data
+        return self.extra_data and ("PostCode" in self.extra_data or "DOB" in self.extra_data)
 
     def authenticate(self, num_charges, postcode, dob):
 

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -1003,7 +1003,7 @@ class CompleteStage(FormStage):
         self.context["plea_type"] = get_plea_type(self.all_data)
 
         try:
-            self.context["court"] = Court.objects.get_by_urn(self.all_data["case"]["urn"])
+            self.context["court"] = Court.objects.get_court_dx(self.all_data["case"]["urn"])
         except Court.DoesNotExist:
             pass
 

--- a/apps/plea/stages.py
+++ b/apps/plea/stages.py
@@ -84,7 +84,9 @@ def get_offences(case_data):
     offences = []
     if urn:
         case = get_case(urn)
-        court = Court.objects.get_by_urn(urn)
+
+        ou_code = case.ou_code if case else None
+        court = Court.objects.get_court(urn, ou_code=ou_code)
 
         # offence_seq_number is a char field so best to cast and order by
         # rather than just grabbing case.offences.all() and hoping it's

--- a/apps/plea/templates/partials/review_details.html
+++ b/apps/plea/templates/partials/review_details.html
@@ -20,12 +20,12 @@
     <dd>{{ your_details.contact_number }}</dd>
 
     <dt>{% blocktrans %}Date of birth{% endblocktrans %}</dt>
-    <dd>{% if your_details.date_of_birth %}
-            {{ your_details.date_of_birth|parse_date|date:"d/m/Y" }}
+    {% if your_details.date_of_birth %}
+    <dd>{{ your_details.date_of_birth|parse_date|date:"d/m/Y" }}</dd>
         {% else %}
-            {{ case.date_of_birth|parse_date|date:"d/m/Y" }}
+    <dd>{{ case.date_of_birth|parse_date|date:"d/m/Y" }}</dd>
         {% endif %}
-    </dd>
+
 
     <dt>{% blocktrans %}National Insurance number{% endblocktrans %}</dt>
     <dd>{{ your_details.ni_number|default:"-" }}</dd>

--- a/apps/plea/tests/test_models.py
+++ b/apps/plea/tests/test_models.py
@@ -3,7 +3,7 @@ import datetime as dt
 
 from django.test import TestCase
 
-from ..models import CourtEmailCount, UsageStats, Court, Case
+from ..models import CourtEmailCount, UsageStats, Court, Case, OUCode
 
 
 class TestStatsBase(TestCase):
@@ -264,7 +264,6 @@ class TestCourtModel(TestCase):
     def setUp(self):
         self.court = Court.objects.create(
             region_code="51",
-            ou_code="12345",
             court_name="Test Court",
             court_address="28 Court Street",
             court_telephone="0800 Court",
@@ -273,9 +272,10 @@ class TestCourtModel(TestCase):
             submission_email="test@court.com",
             enabled=True)
 
+        OUCode.objects.create(court=self.court, ou_code="B01CN")
+
         self.court2 = Court.objects.create(
             region_code="61",
-            ou_code="54321",
             court_name="Test Court 2",
             court_address="29 Court Street",
             court_telephone="0800 Court",
@@ -284,8 +284,10 @@ class TestCourtModel(TestCase):
             submission_email="test@court.com",
             enabled=True)
 
+        OUCode.objects.create(court=self.court2, ou_code="B01LY")
+
         self.case = Case.objects.create(
-            ou_code="54321",
+            ou_code="B01LY11",
             imported=True,
             urn="51XX0000000")
 
@@ -301,10 +303,10 @@ class TestCourtModel(TestCase):
 
     def test_get_by_court_with_ou_code(self):
 
-        self.assertEquals(self.court.id, Court.objects.get_court("99/xx/00000/00", ou_code="12345").id)
+        self.assertEquals(self.court.id, Court.objects.get_court("99/xx/00000/00", ou_code="B01CN11").id)
 
     def test_get_by_court_ou_code_no_match(self):
-        self.assertEquals(self.court.id, Court.objects.get_court("51/xx/00000/00", ou_code="99999").id)
+        self.assertEquals(self.court.id, Court.objects.get_court("51/xx/00000/00", ou_code="C01CN11").id)
 
     def test_get_by_court_ou_code_and_urn_no_match(self):
         with self.assertRaises(Court.DoesNotExist):

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -160,7 +160,7 @@ class CourtFinderView(FormView):
 
     def form_valid(self, form):
         try:
-            court = Court.objects.get_by_urn(form.cleaned_data["urn"])
+            court = Court.objects.get_court_dx(form.cleaned_data["urn"])
         except Court.DoesNotExist:
             court = False
 

--- a/apps/result/management/commands/process_results.py
+++ b/apps/result/management/commands/process_results.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
 
         # If we move to using OU codes in Case data this should be replaced by a lookup using the
         # Case OU code
-        data["court"] = Court.objects.get_by_standardised_urn(result.urn)
+        data["court"] = Court.objects.get_court(result.urn, ou_code=case.ou_code)
 
         if not data["court"]:
             self.log("URN failed to standardise: {}".format(result.urn))

--- a/make_a_plea/settings/docker.py
+++ b/make_a_plea/settings/docker.py
@@ -59,3 +59,5 @@ ENCRYPTED_COOKIE_KEYS = [
 STORE_USER_DATA = os.environ.get("STORE_USER_DATA", "") == "True"
 
 REDIRECT_START_PAGE = os.environ.get("REDIRECT_START_PAGE", "")
+
+EMAIL_USE_TLS = True


### PR DESCRIPTION
A temporary OU code based routing "hack" to allow the Bromley region to exist alongside Lavender Hill. 
At currently the make-a-plea app determines which court should receive defendant submission emails based on the first two digits of the URN code, but as Bromley and Lavender Hill share the same region, this won't work.

So we're now using the OU code which is supplied for each case by Libra, which correctly identifies the court that a case belongs to.