### PR TITLE
Add a management command to cull old case and resulting data

### DIFF
--- a/make_a_plea/management/commands/delete_old_data.py
+++ b/make_a_plea/management/commands/delete_old_data.py
@@ -1,0 +1,22 @@
+import datetime as dt
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from apps.plea.models import Case
+from apps.result.models import Result
+
+
+class Command(BaseCommand):
+    help = "Delete case and result data that is greater " \
+        "than {} days old".format(settings.DATA_RETENTION_PERIOD)
+
+    def handle(self, *args, **options):
+
+        cut_off_date = dt.datetime.now() - dt.timedelta(settings.DATA_RETENTION_PERIOD)
+
+        Case.objects.filter(
+            created__lt=cut_off_date).delete()
+
+        Result.objects.filter(
+            created__lt=cut_off_date).delete()

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -328,6 +328,8 @@ FTP_SERVER_IP = os.environ.get("FTP_SERVER_IP", "")
 
 AXES_COOLOFF_TIME = 1
 
+DATA_RETENTION_PERIOD = int(os.environ.get("DATA_RETENTION_PERIOD", "57"))
+
 RAVEN_CONFIG = {
     'dsn': os.environ.get("SENTRY_DSN", ""),
     'release': os.environ.get("APP_GIT_COMMIT", "no-git-commit-available")


### PR DESCRIPTION
Add a management command ./manage.py delete_old_data that removes any data older than {settings.DATA_RETENTION_PERIOD} days old.

Associated pull requests have also been made to the ops and soap gateway repos.