### PR TITLE
Add option to show all results, including those that have been resulted

### DIFF
--- a/apps/result/management/commands/generate_result_csv.py
+++ b/apps/result/management/commands/generate_result_csv.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
         parser.add_argument(
             "--show-all",
-            action="store_false",
+            action="store_true",
             dest="show_all",
             default=False,
             help="Show all results including processed results")

--- a/apps/result/management/commands/generate_result_csv.py
+++ b/apps/result/management/commands/generate_result_csv.py
@@ -43,6 +43,13 @@ class Command(BaseCommand):
                  "If not specified the script will default to today"
         )
 
+        parser.add_argument(
+            "--show-all",
+            action="store_false",
+            dest="show_all",
+            default=False,
+            help="Show all results including processed results")
+
     @staticmethod
     def get_result_data(case, result):
         data = OrderedDict()
@@ -53,8 +60,12 @@ class Command(BaseCommand):
         data["ou_code"] = case.ou_code
         data["court"] = Court.objects.get_court(result.urn, ou_code=case.ou_code).court_name
         data["fines"], data["endorsements"], data["total"] = result.get_offence_totals()
+
+        data["fines"] = " / ".join(data["fines"])
+        data["endorsements"] = " / ".join(data["endorsements"])
+
         data["pay_by"] = result.pay_by_date
-        data["division"] = result.division,
+        data["division"] = result.division[0],
         data["account_number"] = result.account_number
 
         return data
@@ -103,9 +114,13 @@ class Command(BaseCommand):
 
         self.csv_write_header()
 
-        for result in Result.objects.filter(processed=False,
-                                            sent=False,
-                                            created__range=filter_date_range):
+        results = Result.objects.filter(
+            processed=False, created__range=filter_date_range)
+
+        if not options["show_all"]:
+            results.filter(sent=False)
+
+        for result in results:
 
             can_result, _ = result.can_result()
 


### PR DESCRIPTION
The CSV command has been amended so that it can list results that have been marked as resulted, using a --show-all option, e.g. 

./manage.py generate_result_csv --show-all

Also the output of the fines, endorsements and division code fields has been cleaned up.