### PR TITLE
RST-144 Remove 'forward email' section from emails

### DIFF
--- a/apps/plea/templates/emails/user_plea_confirmation.txt
+++ b/apps/plea/templates/emails/user_plea_confirmation.txt
@@ -39,11 +39,6 @@ https://www.makeaplea.service.gov.uk/feedback/
 
 ------------------------------------------------------------------------
 
-{% blocktrans %}If you're unsure an email is from the Ministry of Justice:{% endblocktrans %}
-
-- {% blocktrans %}do not reply to it or click any links{% endblocktrans %}
-- {% blocktrans %}forward it to{% endblocktrans %} feedback@makeaplea.gov.uk
-
 {% blocktrans %}Terms and Conditions and Privacy Policy:{% endblocktrans %}
 https://www.makeaplea.service.gov.uk/terms-and-conditions-and-privacy-policy
 

--- a/apps/plea/templates/emails/user_plea_confirmation_sjp.txt
+++ b/apps/plea/templates/emails/user_plea_confirmation_sjp.txt
@@ -36,11 +36,6 @@ https://www.makeaplea.service.gov.uk/feedback/
 
 -------
 
-{% blocktrans %}If you're unsure an email is from the Ministry of Justice:{% endblocktrans %}
-
-- {% blocktrans %}do not reply to it or click any links{% endblocktrans %}
-- {% blocktrans %}forward it to{% endblocktrans %} makeaplea@digital.justice.gov.uk
-
 {% blocktrans %}Terms and Conditions and Privacy Policy:{% endblocktrans %}
 https://www.makeaplea.service.gov.uk/terms-and-conditions-and-privacy-policy
 

--- a/apps/plea/tests/test_email_template_output.py
+++ b/apps/plea/tests/test_email_template_output.py
@@ -829,6 +829,22 @@ class EmailTemplateTests(TestCase):
 
         send_plea_email(data)
 
+    def test_forward_email_section_removed_from_plea_confirmation(self):
+        context_data = self.get_context_data()
+
+        send_plea_email(context_data)
+
+        search_text = "If you're unsure an email is from the Ministry of Justice"
+        self.assertNotIn(search_text, mail.outbox[2].body)
+
+    def test_forward_email_section_removed_from_sjp_plea_confirmation(self):
+        context_data = self.get_context_data(notice_type_data={"sjp": True})
+
+        send_plea_email(context_data)
+
+        search_text = "If you're unsure an email is from the Ministry of Justice"
+        self.assertNotIn(search_text, mail.outbox[2].body)
+
 
 class TestCompanyFinancesEmailLogic(TestCase):
     def setUp(self):

--- a/apps/result/templates/emails/user_resulting.txt
+++ b/apps/result/templates/emails/user_resulting.txt
@@ -64,11 +64,6 @@ www.gov.uk/pay-court-fine-online
 
 ------------------------------------------------------------------------
 
-{% blocktrans %}If you're unsure an email is from the Ministry of Justice:{% endblocktrans %}
-
-- {% blocktrans %}do not reply to it or click any links{% endblocktrans %}
-- {% blocktrans %}forward it to{% endblocktrans %} feedback@makeaplea.gov.uk
-
 {% blocktrans %}Terms and Conditions and Privacy Policy:{% endblocktrans %}
 https://www.makeaplea.service.gov.uk/terms-and-conditions-and-privacy-policy
 

--- a/apps/result/tests.py
+++ b/apps/result/tests.py
@@ -368,4 +368,15 @@ class ProcessResultsTestCase(TestCase):
         self.assertFalse(result.sent)
         self.assertFalse(result.processed)
 
+    def test_forward_email_section_removed_from_plain_text_email(self):
+        self.command.handle(**self.opts)
+
+        search_text = "If you're unsure an email is from the Ministry of Justice"
+        self.assertNotIn(search_text, mail.outbox[0].body)
+
+    def test_forward_email_section_removed_from_html_email(self):
+        self.command.handle(**self.opts)
+
+        search_text = "If you're unsure an email is from the Ministry of Justice"
+        self.assertNotIn(search_text, mail.outbox[0].alternatives[0][0])
 

--- a/conf/locale/cy/LC_MESSAGES/django.po
+++ b/conf/locale/cy/LC_MESSAGES/django.po
@@ -1983,15 +1983,6 @@ msgstr "GOV.UK - Cadarnhad o gofnodi ple ar-lein"
 msgid "Please give us feedback so we can make it better:"
 msgstr "Gofynnwn yn garedig ichi roi adborth inni fel y gallwn ei wella:"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:42
-#: apps/plea/templates/emails/user_plea_confirmation_sjp.txt:39
-#: apps/result/templates/emails/user_resulting.txt:67
-#: make_a_plea/templates/base_user_email.html:225
-msgid "If you're unsure an email is from the Ministry of Justice:"
-msgstr ""
-"Os nad ydych yn siŵr fod neges e-bost wedi cael ei hanfon gan y Weinyddiaeth "
-"Cyfiawnder:"
-
 #: apps/plea/templates/emails/user_plea_confirmation.txt:44
 #: apps/plea/templates/emails/user_plea_confirmation_sjp.txt:41
 #: apps/result/templates/emails/user_resulting.txt:69

--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -1628,13 +1628,6 @@ msgstr "GOV.UK - Online plea submission confirmation"
 msgid "Please give us feedback so we can make it better:"
 msgstr "Please give us feedback so we can make it better:"
 
-#: apps/plea/templates/emails/user_plea_confirmation.txt:42
-#: apps/plea/templates/emails/user_plea_confirmation_sjp.txt:39
-#: apps/plea/templates/emails/user_resulting.txt:84
-#: make_a_plea/templates/base_user_email.html:225
-msgid "If you're unsure an email is from the Ministry of Justice:"
-msgstr "If you're unsure an email is from the Ministry of Justice:"
-
 #: apps/plea/templates/emails/user_plea_confirmation.txt:44
 #: apps/plea/templates/emails/user_plea_confirmation_sjp.txt:41
 #: apps/plea/templates/emails/user_resulting.txt:86

--- a/make_a_plea/templates/base_user_email.html
+++ b/make_a_plea/templates/base_user_email.html
@@ -222,13 +222,6 @@
           <table class="templateContainer" align="center" border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
               <td id="footerCell">
-                <p>{% blocktrans %}If you're unsure an email is from the Ministry of Justice:{% endblocktrans %}</p>
-
-                <ul>
-                    <li>{% blocktrans %}do not reply to it or click any links{% endblocktrans %}</li>
-                    <li>{% blocktrans %}forward it to{% endblocktrans %} <a href="mailto:makeaplea@digital.justice.gov.uk">makeaplea@digital.justice.gov.uk</a></li>
-                </ul>
-
                 <p><a href="/terms-and-conditions-and-privacy-policy">{% blocktrans %}Terms and Conditions and privacy policy{% endblocktrans %}</a></p>
               </td>
             </tr>


### PR DESCRIPTION
As the MaP Service Manager I want users to contact the relevant court and not the MaP email address as the tickets that are received in ZenDesk cannot be actioned by anyone working on Make a Plea.

I have added tests to verify that the text has been removed from the relevant emails. This tests are not so useful long term and could be cleaned up.