### PR TITLE
Fix up Vagrant bootstrap

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -5,7 +5,11 @@ ssh-keyscan -t rsa,dsa -H github.com >> /home/vagrant/.ssh/known_hosts
 sudo add-apt-repository ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get -y install git postgresql postgresql-contrib postgresql-server-dev-9.3 build-essential python-dev libxml2-dev libxslt-dev python-setuptools nodejs ruby-sass libfontconfig redis-server libssl-dev libffi-dev
+sudo apt-get -y install \
+  git postgresql postgresql-contrib postgresql-server-dev-9.3 \
+  build-essential python-dev libxml2-dev libxslt-dev python-setuptools \
+  nodejs ruby-sass libfontconfig redis-server libssl-dev libffi-dev \
+  gettext
 sudo apt-get -y install build-dep python-psycopg2
 sudo apt-get -y install unoconv default-jre
 sudo easy_install pip
@@ -36,10 +40,12 @@ setvirtualenvproject $VIRTUAL_ENV /pleas/
 workon manchester
 
 pip install -r requirements/dev.txt
+pip install -r requirements/testing.txt
 
 sudo -u postgres createdb manchester_traffic_offences
 ./manage.py syncdb --noinput
 ./manage.py migrate --noinput
+./manage.py compilemessages
 
 sudo npm install -g npm
 npm install


### PR DESCRIPTION
This change adds some missing dependencies to the Vagrant bootstrapping script that tripped me up when starting out with this project.

The `gettext` dependency is required in order to compile the language files.

The test dependencies are added so that tests can easily be run on the Vagrant box.

The language messages are compiled so that the correct language text is inserted.