### PR TITLE
Run tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+dist: trusty
+python:
+  - "2.7"
+services:
+  - postrgresql
+before_install:
+  - sudo ./apt/production.sh
+  - sudo ./apt/testing.sh
+install:
+  - "pip install setuptools==32"
+  - "pip install -r requirements.txt"
+  - "pip install -r requirements/testing.txt"
+before_script:
+  - "psql -c 'CREATE DATABASE manchester_traffic_offences;' -U postgres"
+  - "python manage.py syncdb --noinput"
+  - "python manage.py compilemessages"
+env:
+  - POSTGRES_USER=postgres DJANGO_SETTINGS_MODULE=make_a_plea.settings.testing
+script:
+  - "python manage.py test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ ENV APP_HOME=/makeaplea/
 ENV DJANGO_SETTINGS_MODULE=make_a_plea.settings.docker
 WORKDIR $APP_HOME
 
-RUN apt-get -y update && apt-get -y install python-psycopg2 gettext gnupg
+ADD apt/ $APP_HOME/apt
+
+RUN apt-get -y update && $APT_HOME/apt/production.sh
 
 COPY requirements.txt $APP_HOME
 ADD requirements/ $APP_HOME/requirements/

--- a/apt/development.sh
+++ b/apt/development.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+apt-get install --fix-missing -y \
+  git \
+  postgresql \
+  postgresql-contrib \
+  postgresql-server-dev-9.3 \
+  build-essential \
+  python-dev \
+  libxml2-dev \
+  libxslt-dev \
+  python-setuptools \
+  nodejs \
+  ruby-sass \
+  libfontconfig \
+  redis-server \
+  libssl-dev \
+  libffi-dev

--- a/apt/production.sh
+++ b/apt/production.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+apt-get install --fix-missing -y \
+  python-psycopg2 \
+  gettext \
+  gnupg

--- a/apt/testing.sh
+++ b/apt/testing.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+

--- a/make_a_plea/settings/testing.py
+++ b/make_a_plea/settings/testing.py
@@ -16,6 +16,7 @@ DATABASES = {
     }
 }
 
+EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 BROKER_BACKEND = 'memory'

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -5,13 +5,9 @@ ssh-keyscan -t rsa,dsa -H github.com >> /home/vagrant/.ssh/known_hosts
 sudo add-apt-repository ppa:chris-lea/node.js
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get -y install \
-  git postgresql postgresql-contrib postgresql-server-dev-9.3 \
-  build-essential python-dev libxml2-dev libxslt-dev python-setuptools \
-  nodejs ruby-sass libfontconfig redis-server libssl-dev libffi-dev \
-  gettext
-sudo apt-get -y install build-dep python-psycopg2
-sudo apt-get -y install unoconv default-jre
+sudo ./apt/production.sh
+sudo ./apt/development.sh
+sudo ./apt/testing.sh
 sudo easy_install pip
 sudo pip install virtualenvwrapper
 

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -14,13 +14,14 @@ sudo pip install virtualenvwrapper
 cd /home/vagrant/
 mkdir -p .envs
 
-sed -i '$a\
-\
-export WORKON_HOME=/home/vagrant/.envs\
-source /usr/local/bin/virtualenvwrapper.sh\
-workon manchester\
-echo -e "\\n\\n\\033[0;31mRun: ./manage.py runserver 0.0.0.0:8000\\033[0m\\n\\n"\
-' .bashrc
+
+grep -q '# make a plea startup' .bashrc || cat << EOF >> .bashrc
+# make a plea startup
+export WORKON_HOME=/home/vagrant/.envs
+source /usr/local/bin/virtualenvwrapper.sh
+workon manchester
+echo -e "\\n\\n\\033[0;31mRun: ./manage.py runserver 0.0.0.0:8000\\033[0m\\n\\n"
+EOF
 
 echo "Setting VE wrapper"
 WORKON_HOME=/home/vagrant/.envs


### PR DESCRIPTION
This change introduces a `.travis.yml` file so that the unit tests can
be run in travis against each branch. It also moves apt dependencies out
into separate scripts so that they can be more consistently shared
between `Dockerfile`, Vagrant and Travis.

I have not included npm asset building because apparently the assets are
committed to the repo and re-building is done as an offline task.