### PR TITLE
Improve Welsh ofence display in result email

### DIFF
--- a/apps/result/models.py
+++ b/apps/result/models.py
@@ -139,7 +139,7 @@ class Result(models.Model):
         for offence in self.result_offences.all():
             for r in offence.offence_data.all():
                 if r.result_code.startswith("F"):
-                    values = re.findall(r'\xa3([0-9]+\.*[0-9]{0,2})', r.result_wording_by_language)
+                    values = re.findall(r'\xa3([0-9]+\.*[0-9]{0,2})', r.result_wording)
                     value = sum(Decimal(v) for v in values)
                     total += value
                     fines.append(r.result_wording_by_language)
@@ -173,14 +173,14 @@ class ResultOffenceData(models.Model):
 
     @property
     def result_short_title_by_language(self):
-        if self.language == "cy" and self.result_short_title_welsh:
+        if self.language == "cy" and self.result_short_title_welsh and self.result_short_title_welsh.strip():
             return self.result_short_title_welsh
         else:
             return self.result_short_title
 
     @property
     def result_wording_by_language(self):
-        if self.language == "cy" and self.result_wording_welsh:
+        if self.language == "cy" and self.result_wording_welsh and self.result_wording_welsh.strip():
             return self.result_wording_welsh
         else:
             return self.result_wording

--- a/apps/result/tests.py
+++ b/apps/result/tests.py
@@ -217,6 +217,26 @@ class ResultTestCase(TestCase):
 
         self.assertEquals(fines[0], u"english words £75.00 more english")
 
+    def test_get_offence_totals_fines_wording_welsh_but_whitespace_welsh_text(self):
+
+        self.test_case1.language = "cy"
+        self.test_case1.save()
+
+        self.adjourned_offence = ResultOffenceData.objects.create(
+            result_offence=self.offence1,
+            result_code="FCOST",
+            result_short_title="FINE",
+            result_wording=u"english words £75.00 more english",
+            result_short_title_welsh="dirwy",
+            result_wording_welsh=u"  "
+
+        )
+
+        fines, _, _ = self.test_result1.get_offence_totals()
+
+        self.assertEquals(fines[0], u"english words £75.00 more english")
+
+
     def test_get_offence_totals_endorsements(self):
 
         self.adjourned_offence = ResultOffenceData.objects.create(


### PR DESCRIPTION
Some investigation has shown that the Welsh result wording
(`ResultOffenceData.result_wording_welsh`) often has just whitespace in
it. This change first trims the value when testing whether it's empty.

Given that there is a risk that the Welsh result wording may have
text in it that does not correctly represent the result wording I have
changed the code that scans the wording for the fine value back to using
the English wording only.