### PR TITLE
Use production URLs in emails

### DIFF
--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -60,6 +60,13 @@ INSTALLED_APPS = INSTALLED_APPS + PROJECT_APPS
 
 del TEMPLATE_CONTEXT_PROCESSORS[TEMPLATE_CONTEXT_PROCESSORS.index('apps.feedback.context_processors.feedback')]
 
+# Options for Premailer, which inlines the CSS on the fly in email templates and
+# makes all URLs absolute
+PREMAILER_OPTIONS = {"base_url": os.environ.get("PREMAILER_BASE_URL", "https://www.makeaplea.service.gov.uk"),
+                     "remove_classes": False,
+                     "keep_style_tags": True,
+                     "cssutils_logging_level": logging.ERROR}
+
 # .local.py overrides all the common settings.
 try:
     from .local import *

--- a/api/settings/docker.py
+++ b/api/settings/docker.py
@@ -16,11 +16,6 @@ DATABASES = {
     }
 }
 
-PREMAILER_OPTIONS = {"base_url": "http://dev.makeaplea.dsd.io",
-                     "remove_classes": False,
-                     "keep_style_tags": True,
-                     "cssutils_logging_level": logging.ERROR}
-
 SMTP_ROUTES["GSI"]["USERNAME"] = os.environ.get("GSI_EMAIL_USERNAME", "")
 SMTP_ROUTES["GSI"]["PASSWORD"] = os.environ.get("GSI_EMAIL_PASSWORD", "")
 SMTP_ROUTES["PNN"]["USERNAME"] = os.environ.get("PNN_EMAIL_USERNAME", "")

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -110,7 +110,7 @@ STATICFILES_FINDERS = (
 
 # Options for Premailer, which inlines the CSS on the fly in email templates and
 # makes all URLs absolute
-PREMAILER_OPTIONS = {"base_url": "https://www.makeaplea.service.gov.uk",
+PREMAILER_OPTIONS = {"base_url": os.environ.get("PREMAILER_BASE_URL", "https://www.makeaplea.service.gov.uk"),
                      "remove_classes": False,
                      "keep_style_tags": True,
                      "cssutils_logging_level": logging.ERROR}

--- a/make_a_plea/settings/docker.py
+++ b/make_a_plea/settings/docker.py
@@ -16,11 +16,6 @@ DATABASES = {
     }
 }
 
-PREMAILER_OPTIONS = {"base_url": "http://dev.makeaplea.dsd.io",
-                     "remove_classes": False,
-                     "keep_style_tags": True,
-                     "cssutils_logging_level": logging.ERROR}
-
 GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", None)
 
 SMTP_ROUTES["GSI"]["USERNAME"] = os.environ.get("GSI_EMAIL_USERNAME", "")


### PR DESCRIPTION
RST-210 highlighted that non-production URLs were being sent out in
production emails. This change fixes that and defaults them to
production URls. There is a corresponding change in the deployment
scripts to set an appropriate base URL in each environment.