### PR TITLE
Fix cookie security issues

### DIFF
--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -145,11 +145,13 @@ CACHE_MIDDLEWARE_SECONDS = 0
 ROOT_URLCONF = 'make_a_plea.urls'
 
 SESSION_SERIALIZER = 'make_a_plea.serializers.DateAwareSerializer'
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+SESSION_ENGINE = 'encrypted_cookies'
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = True
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 3600
+
+COMPRESS_ENCRYPTED_COOKIE=True
 
 CSRF_COOKIE_HTTPONLY = True
 

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -147,6 +147,7 @@ ROOT_URLCONF = 'make_a_plea.urls'
 SESSION_SERIALIZER = 'make_a_plea.serializers.DateAwareSerializer'
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SECURE = True
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 3600
 

--- a/make_a_plea/settings/docker.py
+++ b/make_a_plea/settings/docker.py
@@ -33,9 +33,6 @@ ALLOWED_HOSTS = [os.environ.get("ALLOWED_HOSTS", "localhost:8000"), ]
 # Enable CachedStaticFilesStorage for cache-busting assets
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
 
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
-
 CELERY_ALWAYS_EAGER = os.environ.get("CELERY_ALWAYS_EAGER", False)
 BROKER_URL = os.environ.get("CELERY_BROKER_URL", "SQS://")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,11 @@ Pillow==2.8.1
 psycopg2==2.5.4
 python-dateutil==2.4.2
 python-gnupg==0.3.7
-git+https://github.com/elbeanio/django-encrypted-cookie-session.git
 git+https://github.com/ministryofjustice/django-moj-irat
 
 django_extensions==1.5.3
 django-brake==1.3.1
+django-encrypted-cookie-session==3.2.0
 django-waffle==0.10.1
 django-celery==3.1.16
 djangorestframework==3.3.1


### PR DESCRIPTION
##  	Set secure flag on session and csrf cookies

For some reason the `production` settings isn't used for production. Instead the `docker` settings file is used. This explicitly disables secure cookies. To avoid problems on local development add the following to your `make_a_plea/settings/local.py` file.

```
SESSION_COOKIE_SECURE = False
CSRF_COOKIE_SECURE = False
```

## Properly configure django-encrypted-cookie-session

This library is not used unless the `SESSION_ENGINE` is set correctly. This change also switches to the main pypi version rather than a github fork that hasn't been updated in 2 years.

Encrypted cookie compression has been enabled because we have a few text fields that can get very long.

This change will break local development unless the local settings is updated to include an `ENCRYPTED_COOKIE_KEYS` setting. This could be avoided if we pulled some of the local settings into a base development
config.