### PR TITLE
Fixed: passed event_trace, checked event_trace

### DIFF
--- a/api/api_test_v0_case.py
+++ b/api/api_test_v0_case.py
@@ -245,5 +245,5 @@ class CaseAPICallTestCase(APITestCase):
 
         self.assertEqual(len(aes), count_before + 1)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(aes[0].event_type, "case_api")
+        self.assertEqual(aes[0].event_type, "urn_validator")
         self.assertEqual(aes[0].event_subtype, "case_invalid_invalid_urn")

--- a/api/v0/serializers.py
+++ b/api/v0/serializers.py
@@ -62,7 +62,8 @@ class CaseSerializer(serializers.ModelSerializer):
             AuditEvent().populate(
                 event_type="case_api",
                 event_subtype="invalid_case_missing_dateofhearing",
-                **data)
+                event_trace=str(data),
+            )
             raise serializers.ValidationError(
                 "date_of_hearing is a required field")
 
@@ -70,7 +71,8 @@ class CaseSerializer(serializers.ModelSerializer):
             AuditEvent().populate(
                 event_type="case_api",
                 event_subtype="case_invalid_no_offences",
-                **data)
+                event_trace=str(data),
+            )
             raise serializers.ValidationError("case has no offences")
 
         offence_codes = [
@@ -86,7 +88,8 @@ class CaseSerializer(serializers.ModelSerializer):
             AuditEvent().populate(
                 event_type="case_api",
                 event_subtype="case_invalid_not_in_whitelist",
-                **data)
+                event_trace=str(data),
+            )
             raise serializers.ValidationError(
                 ("Case {} contains offence codes [{}] not present "
                  "in the whitelist").format(
@@ -107,7 +110,8 @@ class CaseSerializer(serializers.ModelSerializer):
             AuditEvent().populate(
                 event_type="case_api",
                 event_subtype="case_invalid_duplicate_urn_used",
-                **data)
+                event_trace=str(data),
+            )
             raise serializers.ValidationError(
                 "URN / Case number already exists and has been used")
 
@@ -147,6 +151,7 @@ class CaseSerializer(serializers.ModelSerializer):
         AuditEvent().populate(
             event_type="case_api",
             event_subtype="success",
+            event_trace=str(case),
             case=case,
         )
 
@@ -196,7 +201,9 @@ class ResultSerializer(serializers.ModelSerializer):
         if sent_results:
             AuditEvent().populate(
                 event_type="result_api",
-                event_subtype="result_invalid_duplicate_urn_used")
+                event_subtype="result_invalid_duplicate_urn_used",
+                event_trace="URN: {0}".format(urn),
+            )
             raise serializers.ValidationError(
                 "URN / Result number already exists and has been used")
 

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -385,6 +385,7 @@ class Case(models.Model):
             case=self,
             event_type="case_model",
             event_subtype="success",
+            event_trace="Case {0} was updated".format(self.urn),
             **kwargs)
 
 
@@ -764,6 +765,7 @@ class AuditEvent(models.Model):
         ("case_model", "Case Save event"),  # save operations on the model
         ("case_form", "Case Form event"),  # form validation issues
         ("case_api", "Case API event"),  # issue at the Case api
+        ("urn_validator", "URN validation event"),  # issue vaidating a URN
         ("result_api", "Result API event"),  # issue at the Result api
         ("auditevent_api", "AuditEvent API event"),  # issue with an external component
     )
@@ -919,8 +921,8 @@ class AuditEvent(models.Model):
                 if i[0] == kwargs["event_subtype"]][0]
 
         self.event_data = kwargs["event_data"] \
-                if "event_data" in kwargs \
-                else ""
+            if "event_data" in kwargs \
+            else ""
         self.event_trace = kwargs["event_trace"] \
             if "event_trace" in kwargs \
             else ""
@@ -973,6 +975,10 @@ class AuditEvent(models.Model):
             for k, v in kwargs.items():
                 if k not in self.IGNORED_VALIDATOR_FIELDS:
                     self.event_data[k] = v
+
+        self.event_trace = kwargs["event_trace"] \
+            if "event_trace" in kwargs \
+            else ""
 
         self.save()
 

--- a/apps/plea/validators.py
+++ b/apps/plea/validators.py
@@ -61,9 +61,9 @@ def is_urn_valid(urn):
         urn = standardise_urn(urn)
     except StandardiserNoOutputException:
         AuditEvent().populate(
-            event_type="case_api",
+            event_type="urn_validator",
             event_subtype="case_invalid_invalid_urn",
-            urn=urn,
+            event_trace="'is_urn_valid' raised StandardiserNoOutputException with URN {0}.format(urn)",
         )
         raise exceptions.ValidationError(
             "The URN is not valid",
@@ -79,9 +79,9 @@ def is_urn_valid(urn):
     """
     if not re.match(pattern, urn) or not Court.objects.has_court(urn):
         AuditEvent().populate(
-            event_type="case_api",
+            event_type="urn_validator",
             event_subtype="case_invalid_invalid_urn",
-            urn=urn,
+            event_trace="'is_urn_valid' found either no matching urn pattern or no matching court with URN {0}.format(urn)",
         )
         raise exceptions.ValidationError(
             "The URN is not valid",
@@ -91,11 +91,13 @@ def is_urn_valid(urn):
     if court.validate_urn:
         if not Case.objects.filter(urn__iexact=urn, sent=False).exists():
             AuditEvent().populate(
-                event_type="case_api",
+                event_type="urn_validator",
                 event_subtype="case_invalid_invalid_urn",
-                urn=urn,
+                event_trace="'is_urn_valid' found no unsent case matching a strictly validating court with URN {0}.format(urn)",
             )
-            raise exceptions.ValidationError("The URN is not valid", code="is_urn_valid")
+            raise exceptions.ValidationError(
+                "The URN is not valid",
+                code="is_urn_valid")
 
     return True
 
@@ -106,12 +108,12 @@ def is_valid_urn_format(urn):
 
     if not re.match(pattern, urn):
         AuditEvent().populate(
-            event_type="case_api",
+            event_type="urn_validator",
             event_subtype="case_invalid_invalid_urn",
-            urn=urn,
+            event_trace="'is_valid_urn_format' found no matching urn pattern with URN {0}.format(urn)",
         )
         raise exceptions.ValidationError(
-            "The URN is not valid", code="is_urn_valid")
+            "The URN is not valid",
+            code="is_urn_valid")
 
     return True
-


### PR DESCRIPTION
Closes: RST-340

event_trace was not being passed to populate everywhere it was called, this was causing some audit events to be less than informative.
event_trace was not being checked when the audit event was saved, requiring it to be passed, else triggering an exception.
