### PR TITLE
Fix session loading bug

### DIFF
--- a/apps/forms/fields.py
+++ b/apps/forms/fields.py
@@ -66,11 +66,13 @@ class DateWidget(MultiWidget):
         super(DateWidget, self).__init__(widgets, attrs)
 
     def decompress(self, value):
-        if value:
+        if not value:
+            return ["", "", ""]
+        elif isinstance(value, datetime.date):
+            return [value.day, value.month, value.year]
+        else:
             year, month, day = value.split("-")
             return [day, month, year]
-        else:
-            return ["", "", ""]
 
     def value_from_datadict(self, data, files, name):
         day, month, year = [widget.value_from_datadict(data, files, name + '_%s' % i) for i, widget in enumerate(self.widgets)]

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -331,6 +331,37 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
 
         self.assertEqual(response.status_code, 302)
 
+    def test_case_date_of_hearing_stored_as_datetime(self):
+        fake_request = self.get_request_mock("/plea/case/")
+        request_context = RequestContext(fake_request)
+
+        self.session = {
+            "notice_type": {
+                "complete": True,
+                "sjp": False
+            },
+            "case": {
+                "complete": True,
+                "date_of_hearing": datetime.datetime(2015, 1, 1),
+                "urn": "06AA000000015",
+                "number_of_charges": 3,
+                "plea_made_by": "Defendant"
+            }
+        }
+
+        case = Case()
+        case.urn = "06AA000000015"
+        case.name = "frank marsh"
+        case.sent = True
+        case.save()
+
+        form = PleaOnlineForms(self.session, "case")
+        form.load(request_context)
+
+        response = form.render()
+
+        self.assertEqual(response.status_code, 200)
+
     def test_case_stage_redirects_to_company_stage(self):
         form = PleaOnlineForms(self.session, "case")
 


### PR DESCRIPTION
This issue was introduced by
https://github.com/ministryofjustice/manchester_traffic_offences_pleas/pull/335

Dates are now being saved as date objects (it looks like cookie
serialisation changed from JSON based to Pickle based). Mostly this
works seamlessly, except for when returning to a page that preloads a
date field with previously entered data. This was just expecting the
date to be a string and splitting on it.

Other places that deal with this context handle both cases. For example;
https://github.com/ministryofjustice/manchester_traffic_offences_pleas/blob/master/apps/plea/models.py#L200