### PR TITLE
RST319 upgrade dependencies step 1

### DIFF
--- a/apps/forms/templatetags/date.py
+++ b/apps/forms/templatetags/date.py
@@ -1,3 +1,4 @@
+from datetime import datetime, date
 from dateutil import parser
 from django import template
 
@@ -7,8 +8,9 @@ register = template.Library()
 
 @register.filter(name='parse_date')
 def parse_date(value):
-    if isinstance(value, basestring):
-        dt = parser.parse(value)
-    else:
-        dt = value
-    return dt
+    try:
+        return parser.parse(value)
+    except ValueError:
+        return "Unknown"
+    except TypeError:
+        return value

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ psycopg2==2.5.4
 python-dateutil==2.4.2
 python-gnupg==0.3.7
 git+https://github.com/ministryofjustice/django-moj-irat
+raven==6.0.0
 
 django_extensions==1.5.3
 django-brake==1.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,11 +3,9 @@
 # to each package in each requirements/*.txt.
 
 Django==1.8
-lxml==3.4.4
-Pillow==2.8.1
-psycopg2==2.5.4
-python-dateutil==2.4.2
-python-gnupg==0.3.7
+psycopg2==2.7.1
+python-dateutil==2.6.0
+python-gnupg==0.4.0
 git+https://github.com/ministryofjustice/django-moj-irat
 raven==6.0.0
 
@@ -17,11 +15,10 @@ django-encrypted-cookie-session==3.2.0
 django-waffle==0.10.1
 django-celery==3.1.16
 djangorestframework==3.3.1
-django-premailer
+django-premailer==0.2.0
 django-axes==1.6.0
 django-nested-admin==2.2.3
 
-requests==2.7.0
 unicodecsv==0.14.1
 
 # GOVUK Template

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,6 @@
 
 celery[sqs]==3.1.17
 mock==1.0.1
-raven==5.3.1
 ipdb==0.8
 redgreenunittest==0.1.1
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,4 +3,3 @@
 boto
 celery[sqs]==3.1.17
 gunicorn
-raven

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -31,6 +31,7 @@ source /usr/local/bin/virtualenvwrapper.sh
 echo "Setting up postgres"
 sudo cp /pleas/vagrant/pg_hba.conf /etc/postgresql/9.3/main/pg_hba.conf
 sudo service postgresql restart
+sudo -u postgres bash -c "psql postgres -tAc 'SELECT 1 FROM pg_roles WHERE rolname='\''jenkins'\' | grep -q 1 || createuser --superuser jenkins"
 
 echo "Making the VE"
 mkvirtualenv manchester

--- a/vagrant/reset.sh
+++ b/vagrant/reset.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Reset the database and dependencies to those on master
+
+git checkout master
+sudo -u postgres dropdb manchester_traffic_offences && sudo -u postgres createdb manchester_traffic_offences
+
+./vagrant/update.sh

--- a/vagrant/update.sh
+++ b/vagrant/update.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Update dependencies and the database
+pip install -r requirements/dev.txt && pip install -r requirements/testing.txt
+./manage.py migrate


### PR DESCRIPTION
This change adds some helper scripts to make the process and upgrades the non-django related dependencies (ie. the easy ones). There have been some difficulties with some of the Django related upgrades so I'm trying to do them in a series of smaller pull requests rather than one big one.