### PR TITLE
Fix Celery integration for Celery upgrade

### DIFF
--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -11,7 +11,8 @@ from django.utils import translation
 
 from apps.plea.attachment import TemplateAttachmentEmail
 
-from make_a_plea.celery import app
+from celery import shared_task
+
 from apps.plea.models import Case, CourtEmailCount, Court
 from apps.plea.standardisers import format_for_region
 
@@ -37,7 +38,7 @@ def get_court(urn, ou_code):
     return court_obj
 
 
-@app.task(bind=True, max_retries=10, default_retry_delay=900)
+@shared_task(bind=True, max_retries=10, default_retry_delay=900)
 def email_send_court(self, case_id, count_id, email_data):
     smtp_route = "GSI"
 
@@ -94,7 +95,7 @@ def email_send_court(self, case_id, count_id, email_data):
     return True
 
 
-@app.task(bind=True, max_retries=10, default_retry_delay=1800)
+@shared_task(bind=True, max_retries=10, default_retry_delay=1800)
 def email_send_prosecutor(self, case_id, email_data):
     smtp_route = "PNN"
 
@@ -136,7 +137,7 @@ def email_send_prosecutor(self, case_id, email_data):
     return True
 
 
-@app.task(bind=True, max_retries=10, default_retry_delay=1800)
+@shared_task(bind=True, max_retries=10, default_retry_delay=1800)
 def email_send_user(self, case_id, email_address, subject, html_body, txt_body):
     """
     Dispatch an email to the user to confirm that their plea submission

--- a/docker/celery_defaults
+++ b/docker/celery_defaults
@@ -11,7 +11,7 @@ CELERY_BIN="/usr/local/bin/celery"
 
 # App instance to use
 # comment out this line if you don't use an app
-CELERY_APP="apps.plea.tasks:app"
+CELERY_APP="make_a_plea.celery:app"
 
 # Where to chdir at start.
 CELERYD_CHDIR="/makeaplea/"

--- a/docker/run_celery.sh
+++ b/docker/run_celery.sh
@@ -4,5 +4,5 @@ export PATH=$PATH:/makeaplea/
 
 export C_FORCE_ROOT=true
 
-cd /makeaplea && source /makeaplea/docker/celery_defaults && celery worker -A apps.plea.tasks:app
+cd /makeaplea && source /makeaplea/docker/celery_defaults && celery worker -A make_a_plea.celery:app
 


### PR DESCRIPTION
After the Celery upgrade in ministryofjustice/manchester_traffic_offences_pleas#345 the Celery
worker container started failing with the following exception:

```
Traceback (most recent call last):
  File "/usr/local/bin/celery", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/celery/__main__.py", line 14, in main
    _main()
  File "/usr/local/lib/python2.7/site-packages/celery/bin/celery.py", line 326, in main
    cmd.execute_from_commandline(argv)
  File "/usr/local/lib/python2.7/site-packages/celery/bin/celery.py", line 488, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/usr/local/lib/python2.7/site-packages/celery/bin/base.py", line 279, in execute_from_commandline
    argv = self.setup_app_from_commandline(argv)
  File "/usr/local/lib/python2.7/site-packages/celery/bin/base.py", line 481, in setup_app_from_commandline
    self.app = self.find_app(app)
  File "/usr/local/lib/python2.7/site-packages/celery/bin/base.py", line 503, in find_app
    return find_app(app, symbol_by_name=self.symbol_by_name)
  File "/usr/local/lib/python2.7/site-packages/celery/app/utils.py", line 355, in find_app
    sym = symbol_by_name(app, imp=imp)
  File "/usr/local/lib/python2.7/site-packages/celery/bin/base.py", line 506, in symbol_by_name
    return imports.symbol_by_name(name, imp=imp)
  File "/usr/local/lib/python2.7/site-packages/kombu/utils/imports.py", line 56, in symbol_by_name
    module = imp(module_name, package=package, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/celery/utils/imports.py", line 101, in import_from_cwd
    return imp(module, package=package)
  File "/usr/local/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/makeaplea/apps/plea/tasks.py", line 15, in <module>
    from apps.plea.models import Case, CourtEmailCount, Court
  File "/makeaplea/apps/plea/models.py", line 152, in <module>
    class CourtEmailCount(models.Model):
  File "/usr/local/lib/python2.7/site-packages/django/db/models/base.py", line 94, in __new__
    app_config = apps.get_containing_app_config(module)
  File "/usr/local/lib/python2.7/site-packages/django/apps/registry.py", line 239, in get_containing_app_config
    self.check_apps_ready()
  File "/usr/local/lib/python2.7/site-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

Following the [First steps with Django](http://docs.celeryproject.org/en/v4.0.2/django/first-steps-with-django.html) and and [First steps with Celery](http://docs.celeryproject.org/en/v4.0.2/getting-started/first-steps-with-celery.html) guides suggests that the way we're starting the celery workers is not correct and no longer works.

This change starts the celery worker by pointing at where the celery app is created rather than the tasks module. The use of `app.autodiscover_task()` should mean that all relevant tasks modules are loaded automatically. I have also changed the way we decorate the tasks to follow the advice in the [first steps with Django guide](http://docs.celeryproject.org/en/v4.0.2/django/first-steps-with-django.html#using-the-shared-task-decorator).