### PR TITLE
Add debug logging to celery worker

### DIFF
--- a/docker/run_celery.sh
+++ b/docker/run_celery.sh
@@ -4,5 +4,5 @@ export PATH=$PATH:/makeaplea/
 
 export C_FORCE_ROOT=true
 
-cd /makeaplea && source /makeaplea/docker/celery_defaults && celery worker -A make_a_plea.celery:app
+cd /makeaplea && source /makeaplea/docker/celery_defaults && celery -A make_a_plea.celery:app worker --loglevel=DEBUG
 


### PR DESCRIPTION
The celery worker is exiting silently when deployed to an environment.
This change swaps the celery arguments to match the docs [1] and adds
debug logging.

[1] http://docs.celeryproject.org/en/latest/userguide/workers.html#starting-the-worker