### PR TITLE
Add pycurl dependency

### DIFF
--- a/apt/production.sh
+++ b/apt/production.sh
@@ -3,4 +3,5 @@
 apt-get install --fix-missing -y \
   python-psycopg2 \
   gettext \
-  gnupg
+  gnupg \
+  libcurl4-openssl-dev

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@
 
 Django==1.9
 psycopg2==2.7.1
+pycurl==7.43.0
 python-dateutil==2.6.0
 python-gnupg==0.4.0
 git+https://github.com/ministryofjustice/django-moj-irat


### PR DESCRIPTION
This is apparently a silent dependency of the updated Celery SQS
transport. Running the celery worker was starting up correctly and then
just cancelling the consumer. A lot of debugging showed that the
exception causing the shutdown was being swallowed and not displayed.