### PR TITLE
RST 319 upgrade dependencies step 3

### DIFF
--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -58,7 +58,7 @@ REST_FRAMEWORK = {
 
 INSTALLED_APPS = INSTALLED_APPS + PROJECT_APPS
 
-del TEMPLATE_CONTEXT_PROCESSORS[TEMPLATE_CONTEXT_PROCESSORS.index('apps.feedback.context_processors.feedback')]
+TEMPLATES[0]['OPTIONS']['context_processors'].remove('apps.feedback.context_processors.feedback')
 
 # Options for Premailer, which inlines the CSS on the fly in email templates and
 # makes all URLs absolute

--- a/api/v0/serializers.py
+++ b/api/v0/serializers.py
@@ -254,3 +254,4 @@ class UsageStatsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UsageStats
+        fields = '__all__'

--- a/apps/feedback/urls.py
+++ b/apps/feedback/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns("",
+urlpatterns = [
     url(r"^(?P<stage>.+)/$", views.FeedbackViews.as_view(), name="feedback_form_step"),
     url(r"^$", views.FeedbackViews.as_view(), name="feedback_form"),
-)
+]

--- a/apps/feedback/views.py
+++ b/apps/feedback/views.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.conf import settings
 from django.core.urlresolvers import reverse_lazy, reverse
 from django.http import HttpResponseRedirect
-from django.shortcuts import RequestContext
+from django.template import RequestContext
 
 from apps.forms.stages import MultiStageForm
 from apps.forms.views import StorageView

--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -165,7 +165,7 @@ class DataValidationAdmin(admin.ModelAdmin):
     change_list_template = "admin/datavalidation_change_list.html"
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
 
         def wrap(view):
             def wrapper(*args, **kwargs):
@@ -174,14 +174,13 @@ class DataValidationAdmin(admin.ModelAdmin):
 
         info = self.model._meta.app_label, self.model._meta.model_name
 
-        urls = patterns(
-            '',
+        urls = [
             url(
                 r'^statistics/$',
                 wrap(self.statistics_view),
                 name='%s_%s_statistics' % info
             ),
-        )
+        ]
 
         super_urls = super(DataValidationAdmin, self).get_urls()
 

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -886,9 +886,6 @@ class AuditEvent(models.Model):
 
     def populate(self, *args, **kwargs):
         """
-        Use of _meta.get_all_field_names() needs changing for Django 1.9
-        http://stackoverflow.com/questions/2170228/iterate-over-model-instance-field-names-and-values-in-template
-
         TODO: Visitor pattern made sense when I started this work, not as much anymore
         """
 
@@ -939,10 +936,8 @@ class AuditEvent(models.Model):
             self.case = case
 
             # Copy the fields of interest
-            fieldnames = case._meta.get_all_field_names()
-            for fieldname in fieldnames:
-                if fieldname not in self.IGNORED_CASE_FIELDS:
-                    field = getattr(case, fieldname)
+            for field in case._meta.get_fields():
+                if field.name not in self.IGNORED_CASE_FIELDS:
                     if hasattr(field, 'name') and hasattr(field, "value"):
                         if field.name != "extra_data":
                             self.event_data[field.name] = field.value

--- a/apps/plea/urls.py
+++ b/apps/plea/urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^urn_used/$', views.UrnAlreadyUsedView.as_view(), name='urn_already_used'),
     url(r'^(?P<stage>.+)/(?P<index>.+)$', views.PleaOnlineViews.as_view(), name='plea_form_step'),
     url(r'^(?P<stage>.+)/$', views.PleaOnlineViews.as_view(), name='plea_form_step'),
     url(r'^$', views.PleaOnlineViews.as_view(), name='plea_form'),
-)
+]

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -2,8 +2,9 @@ from django.utils.decorators import method_decorator
 from django.conf import settings
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
-from django.shortcuts import RequestContext, redirect
+from django.shortcuts import redirect
 from django.views.generic import FormView
+from django.template import RequestContext
 
 from brake.decorators import ratelimit
 

--- a/apps/receipt/urls.py
+++ b/apps/receipt/urls.py
@@ -1,6 +1,7 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns('',
-    url(r'^webhook/$', views.ReceiptWebhook.as_view(), name="receipt_webhook"))
+urlpatterns = [
+    url(r'^webhook/$', views.ReceiptWebhook.as_view(), name="receipt_webhook")
+]

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -118,11 +118,30 @@ PREMAILER_OPTIONS = {"base_url": os.environ.get("PREMAILER_BASE_URL", "https://w
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = os.environ.get("SECRET_KEY", "")
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.app_directories.Loader',
-    'django.template.loaders.filesystem.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            "templates",
+            root('templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                'django.template.context_processors.request',
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "django.contrib.auth.context_processors.auth",
+                "make_a_plea.context_processors.globals",
+                "apps.feedback.context_processors.feedback",
+            ]
+        }
+    }
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.cache.UpdateCacheMiddleware',
@@ -161,24 +180,6 @@ WAFFLE_CACHE_PREFIX = "MaP_waffle"
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'make_a_plea.wsgi.application'
-
-TEMPLATE_DIRS = (
-    "templates",
-    root('templates'),
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = [
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    'django.core.context_processors.request',
-    "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "django.contrib.auth.context_processors.auth",
-    "make_a_plea.context_processors.globals",
-    "apps.feedback.context_processors.feedback",
-]
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/make_a_plea/urls.py
+++ b/make_a_plea/urls.py
@@ -5,7 +5,7 @@ from moj_irat.views import PingJsonView, HealthcheckView
 import views
 
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
@@ -16,8 +16,7 @@ admin.autodiscover()
 
 handler500 = "make_a_plea.views.server_error"
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^$", views.start, name="home"),
     url(r"^helping-you-plead-online/$", views.TranslatedView.as_view(template_name="ad_support.html"), name="ad_support"),
     url(r"^terms-and-conditions-and-privacy-policy/$", views.TranslatedView.as_view(template_name="terms.html"), name="terms"),
@@ -38,4 +37,4 @@ urlpatterns = patterns(
     url(r'^ping.json$', PingJsonView.as_view(build_date_key="APP_BUILD_DATE", commit_id_key="APP_GIT_COMMIT"), name='ping_json'),
     url(r'^500.html$', TemplateView.as_view(template_name="500.html"), name='500_page'),
 
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-Django==1.9
+Django==1.10
 psycopg2==2.7.1
 pycurl==7.43.0
 python-dateutil==2.6.0
@@ -16,7 +16,7 @@ django-brake==1.3.1
 django-encrypted-cookie-session==3.2.0
 django-waffle==0.10.1
 django-celery-results==1.0.1
-djangorestframework==3.3.1
+djangorestframework==3.6.3
 django-premailer==0.2.0
 django-axes==1.6.0
 django-nested-admin==2.2.3


### PR DESCRIPTION
Depends on #348 

# Upgrade Django 1.10

- Upgrade template configuration
  https://docs.djangoproject.com/en/1.11/ref/templates/upgrading/
- Remove use of `urls.patterns`
- Replace `get_all_field_names()` with `get_fields()`
  https://docs.djangoproject.com/en/1.11/releases/1.10/#features-removed-in-1-10

	