### PR TITLE
Fix bug due to Django 1.10 upgrade

### DIFF
--- a/apps/feedback/tests.py
+++ b/apps/feedback/tests.py
@@ -14,7 +14,8 @@ class FeedbackFormTestCase(TestCase):
 
         mail.outbox = []
 
-        self.request_context = {}
+        self.request_context = Mock()
+        self.request_context.request = self.get_request_mock('/dummy')
 
         self.empty_session_data = {}
         self.complete_session_data = {

--- a/apps/forms/stages.py
+++ b/apps/forms/stages.py
@@ -3,7 +3,7 @@ from collections import OrderedDict, namedtuple
 from django.core.urlresolvers import reverse
 from django.contrib import messages
 from django.http import Http404, HttpResponseRedirect, QueryDict
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 
 StageMessage = namedtuple("StageMessage", ["importance", "message", "tags"])
@@ -127,7 +127,8 @@ class FormStage(object):
             context = self.context
             context.update({k: v for (k, v) in self.all_data.items()})
             context["form"] = self.form
-            return render_to_response(self.template, context, request_context)
+            # TODO: refactor API to accept a request object rather than request context
+            return render(request_context.request, self.template, context)
 
 
 class IndexedStage(FormStage):

--- a/apps/plea/admin.py
+++ b/apps/plea/admin.py
@@ -6,7 +6,7 @@ from functools import update_wrapper
 from django.core import urlresolvers
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.db.models import Count
 
@@ -236,12 +236,12 @@ class DataValidationAdmin(admin.ModelAdmin):
                        "change_percentage": change_percentage}
                 regions.append(reg)
 
-        return render_to_response(self.statistics_template, {
+        return render(request, self.statistics_template, {
             'title': 'Data Validation Statistics',
             'opts': self.model._meta,
             'recent_days': recent_days,
             'regions': regions
-        }, context_instance=RequestContext(request))
+        })
 
 
 class UrnFilter(admin.SimpleListFilter):

--- a/apps/plea/tests/test_nojs.py
+++ b/apps/plea/tests/test_nojs.py
@@ -25,7 +25,8 @@ class TestNoJS(TestCase):
                                                   "data": [{"guilty": "guilty",
                                                             "complete": True}]}}
 
-        self.request_context = {}
+        self.request_context = Mock()
+        self.request_context.request = self.get_request_mock("/dummy")
 
     def get_request_mock(self, url, url_name="", url_kwargs=None):
         request_factory = RequestFactory()

--- a/apps/plea/tests/test_plea_form.py
+++ b/apps/plea/tests/test_plea_form.py
@@ -44,7 +44,8 @@ class TestMultiPleaForms(TestMultiPleaFormBase):
             test_mode=False)
 
         self.session = {}
-        self.request_context = {}
+        self.request_context = Mock()
+        self.request_context.request = self.get_request_mock("/dummy")
 
         self.plea_stage_pre_data_1_charge = {"notice_type": {"complete": True,
                                                              "sjp": False},

--- a/apps/plea/tests/test_stages_data.py
+++ b/apps/plea/tests/test_stages_data.py
@@ -4,7 +4,9 @@ from collections import OrderedDict
 
 from django.utils.translation import activate
 from django.test import TestCase, Client
+from django.test.client import RequestFactory
 from apps.plea.views import PleaOnlineViews
+from collections import namedtuple
 
 from ..stages import URNEntryStage, AuthenticationStage, PleaStage
 from ..models import Court, Case, Offence
@@ -136,6 +138,8 @@ class TestURNStageDataBase(TestCase):
                                  ("company_finances", "company_finances"),
                                  ("case", "case"),
                                  ("complete", "complete")))
+        
+        self.request_context = namedtuple('C', 'request')(RequestFactory().get('/dummy'))
 
 
 class TestURNStageNoData(TestURNStageDataBase):
@@ -200,7 +204,7 @@ class TestURNStageDuplicateCases(TestURNStageDataBase):
         stage = URNEntryStage(self.urls, self.data)
         stage.save({"urn": "06AA0000015"})
 
-        response = stage.render({})
+        response = stage.render(self.request_context)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(stage.next_step, "your_case_continued")
 
@@ -210,7 +214,7 @@ class TestURNStageDuplicateCases(TestURNStageDataBase):
         stage = URNEntryStage(self.urls, self.data)
         stage.save({"urn": self.case.urn})
 
-        response = stage.render({})
+        response = stage.render(self.request_context)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(stage.next_step, "notice_type")
 
@@ -593,7 +597,7 @@ class TestPleaAuthStage(TestURNStageDataBase):
 
         stage = PleaStage(self.urls, self.data)
         stage.load_forms({})
-        response = stage.render({})
+        response = stage.render(self.request_context)
 
         offence = self.case.offences.all().first()
 
@@ -616,7 +620,7 @@ class TestPleaAuthStage(TestURNStageDataBase):
 
         stage = PleaStage(self.urls, self.data)
         stage.load_forms({})
-        response = stage.render({})
+        response = stage.render(self.request_context)
 
         self.assertIn(offence.offence_short_title.encode("utf-8"), response.content)
         self.assertIn(offence.offence_wording.encode("utf-8"), response.content)


### PR DESCRIPTION
The API for render_to_response was changed in 1.8 and fully deprecated
in 1.10. The fix is to use the `request` shortcut instead.

This is a quick fix for a production outage, the proper fix involving
chaning the API will come later.

https://docs.djangoproject.com/en/1.10/releases/1.8/#dictionary-and-context-instance-arguments-of-rendering-functions
https://stackoverflow.com/a/38739423