### PR TITLE
Fix Celery 4 upgrade with SQS

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,8 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
+git+https://github.com/celery/kombu@09bd23bbd83344b09cbf38b7257107e560db9f25
+
 Django==1.10
 psycopg2==2.7.1
 pycurl==7.43.0


### PR DESCRIPTION
This change pins Kombu to an unreleased commit that fixes Celery 4 to work properly with SQS.

While testing on the dev environment it became clear that while the celery worker was able to connect to the SQS queue it wasn't actually receiving any messages off it. There is [an issue on Celery 4.0.2](https://github.com/celery/celery/issues/3672) that shows it does not work correctly with SQS. While there is [a fix](https://github.com/celery/kombu/pull/693) that that has been merged on Kombu this has not made it into a release yet which is why this change pins Kombu to a commit on master.

I have tested the Kombu commit with a minimal Django 1.11 app using SQS as the broker.