### PR TITLE
Add boto3 dependency for Celery 4

### DIFF
--- a/docker/run_celery.sh
+++ b/docker/run_celery.sh
@@ -4,5 +4,5 @@ export PATH=$PATH:/makeaplea/
 
 export C_FORCE_ROOT=true
 
-cd /makeaplea && source /makeaplea/docker/celery_defaults && celery -A make_a_plea.celery:app worker --loglevel=DEBUG
+cd /makeaplea && source /makeaplea/docker/celery_defaults && celery -A make_a_plea.celery:app worker
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@
 # to each package in each requirements/*.txt.
 
 git+https://github.com/celery/kombu@09bd23bbd83344b09cbf38b7257107e560db9f25
+boto3==1.4.4
 
 Django==1.10
 psycopg2==2.7.1


### PR DESCRIPTION
This should have been added with #354.

Helpfully Celery doesn't throw any error it just silently exits 😡 