### PR TITLE
RST 337 police email where defendant under 18

### DIFF
--- a/apps/plea/templates/emails/attachments/plp_email.html
+++ b/apps/plea/templates/emails/attachments/plp_email.html
@@ -25,12 +25,10 @@
         </header>
 
         {% if your_details.18_or_under %}
-          <p>
-            <strong>
-              The defendant is 18 years old or under –
-              please review this case and advise HMCTS as to whether you will be continuing with this prosecution
-            </strong>
-          </p>
+          <div class="warning-banner">
+            <strong>The defendant is 18 years old or under</strong><br>
+            Please review this case and advise HMCTS as to whether you will be continuing with this prosecution
+          </div>
         {% endif %}
 
         {% include "partials/review_details.html" %}

--- a/apps/plea/templates/emails/attachments/plp_email.html
+++ b/apps/plea/templates/emails/attachments/plp_email.html
@@ -24,6 +24,15 @@
             {% endif %}
         </header>
 
+        {% if your_details.18_or_under %}
+          <p>
+            <strong>
+              The defendant is 18 years old or under –
+              please review this case and advise HMCTS as to whether you will be continuing with this prosecution
+            </strong>
+          </p>
+        {% endif %}
+
         {% include "partials/review_details.html" %}
     </section>
 

--- a/make_a_plea/templates/base_email_attachment.html
+++ b/make_a_plea/templates/base_email_attachment.html
@@ -69,6 +69,15 @@
             margin: 0;
             border-top: 1px solid #ccc;
         }
+
+        .warning-banner {
+          color: #B10E1E;
+          line-height: 1.25;
+          border-width: 5px;
+          border-style: solid;
+          margin-top: 15px 0;
+          padding: 20px;
+        }
     </style>
 
     <!--[if lt IE 8]>


### PR DESCRIPTION
As a member of the police constabulary I need to know whether the defendant is 18 years old or under.

## Before
<img width="941" alt="Before" src="https://user-images.githubusercontent.com/14287/27871381-6f35f712-619d-11e7-89e6-229e03d3c8a4.png">

## After
<img width="937" alt="After" src="https://user-images.githubusercontent.com/14287/27871369-609a384e-619d-11e7-9783-e63e1e074f99.png">

# Update
The last commit updates this to use a notification banner. This is using the error status colour from [govuk elements](https://govuk-elements.herokuapp.com/colour/#colour-status-colours)
and follows the style used by Digital Marketplace for [notification banners](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/notification-banner.html). The colour contrast [passes WCAG AAA](http://webaim.org/resources/contrastchecker/)

## With warning banner
<img width="980" alt="with warning banner" src="https://user-images.githubusercontent.com/14287/27917805-022f8e94-6265-11e7-8f46-820d53cbe041.png">

## If the styles fail to load
Some mail clients do not load all kinds of styles. If the style fails to load it will look like this.
<img width="977" alt="with warning banner but no styles" src="https://user-images.githubusercontent.com/14287/27917888-3a5c53ce-6265-11e7-99c4-84520fa79269.png">

## Blocked
- [x] Awaiting signoff
