### PR TITLE
update kombu version to prevent 100% CPU usage

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,6 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-git+https://github.com/celery/kombu@09bd23bbd83344b09cbf38b7257107e560db9f25
 boto3==1.4.4
 
 Django==1.11.3
@@ -28,3 +27,11 @@ unicodecsv==0.14.1
 
 # GOVUK Template
 git+https://github.com/froddd/govuk_template_django.git
+
+# Kombu is a library that celery uses under the hood.
+# Kombu v4.0.2 (which ships with celery v4.0.2) doesn't work with SQS due to problems with their use of boto2, so
+# Kombu migrated to boto3 - We're waiting for that to get a release version, and then to get a new version of celery
+# that pulls that in. Until that point, we should override the kombu version to get these SQS fixes.
+# Additionally, kombu master also includes a fix for the main process taking 100% CPU and not distributing tasks (!)
+# See https://github.com/celery/kombu/pull/693 and https://github.com/celery/kombu/pull/760
+https://github.com/celery/kombu/zipball/b2f21289284496efd89acea003ff9c24105b970e


### PR DESCRIPTION
This commit is a straight copy from GOV.UK Notify
https://github.com/alphagov/notifications-api/pull/1088

This pulls in the most recent version of celery/kombu/master - it
prevents situations where the celery MainProcess would consume 100%
CPU while not distributing any tasks to the workers.

Note: If, locally, you already have kombu==4.0.2, you'll have to run
pip install --upgrade https://github.com/celery/kombu/zipball/b2f21289
to get the new version.