### PR TITLE
Partially fixes: RST-442

### DIFF
--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -756,8 +756,6 @@ class AuditEvent(models.Model):
         Audiit events should be sortable
         Audit events should be filterable
         Audit events should be linked to the case where possible
-
-
     """
 
     EVENT_TYPE_CHOICES = (

--- a/make_a_plea/management/commands/delete_old_data.py
+++ b/make_a_plea/management/commands/delete_old_data.py
@@ -3,12 +3,12 @@ import datetime as dt
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
-from apps.plea.models import Case
+from apps.plea.models import AuditEvent, Case
 from apps.result.models import Result
 
 
 class Command(BaseCommand):
-    help = "Delete case and result data that is greater " \
+    help = "Delete auditevent, case and result data that is greater " \
         "than {} days old".format(settings.DATA_RETENTION_PERIOD)
 
     def handle(self, *args, **options):
@@ -20,3 +20,6 @@ class Command(BaseCommand):
 
         Result.objects.filter(
             created__lt=cut_off_date).delete()
+
+        AuditEvent.objects.filter(
+            event_datetime__lt=cut_off_date).delete()


### PR DESCRIPTION
Improves performance of urn search on auditevents when there are many rows in the db by removing urn substring search to hstore fields on related fields.
Adds name to the search fields
Corrects a few issues with field display and search
Remove auditevents from before the retention period