### PR TITLE
Upgrade Celery to 4.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,6 @@
 # After the first "pip install -r", just run "pip freeze" and add the version
 # to each package in each requirements/*.txt.
 
-git+https://github.com/celery/kombu@09bd23bbd83344b09cbf38b7257107e560db9f25
 boto3==1.4.4
 
 Django==1.11.3
@@ -12,7 +11,7 @@ python-dateutil==2.6.0
 python-gnupg==0.4.0
 git+https://github.com/ministryofjustice/django-moj-irat
 raven==6.0.0
-Celery==4.0.2
+Celery==4.1.0
 
 django-extensions==1.7.9
 django-brake==1.3.1


### PR DESCRIPTION
Celery 4.1.0 has been released, this includes the newly cut Kombu 4.1.0
which includes the `boto3` changes. Upgrading to Celery 4.1.0 means that
we no longer have to pin to a specific commit of Kombu.

This supersedes #366  

http://docs.celeryproject.org/en/master/changelog.html#version-4-1-0