### PR TITLE
Add APP_BUILD_TAG to ping.json

### DIFF
--- a/make_a_plea/urls.py
+++ b/make_a_plea/urls.py
@@ -34,7 +34,11 @@ urlpatterns = [
     url(r"^test-email-attachment/$", views.test_email_attachment, name="test_email_attachment"),
     url(r"^test-resulting-email/$", views.test_resulting_email, name="test_resulting_email"),
     url(r'^healthcheck$', HealthcheckView.as_view(), name='healthcheck'),
-    url(r'^ping.json$', PingJsonView.as_view(build_date_key="APP_BUILD_DATE", commit_id_key="APP_GIT_COMMIT"), name='ping_json'),
+    url(r'^ping.json$', PingJsonView.as_view(
+        build_date_key="APP_BUILD_DATE",
+        commit_id_key="APP_GIT_COMMIT",
+        build_tag_key="APP_BUILD_TAG"
+    ), name='ping_json'),
     url(r'^500.html$', TemplateView.as_view(template_name="500.html"), name='500_page'),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
The ping.json view gives provides information about the version of the app that is deployed. This change adds in the docker tag of the deployed app.

This is the same as how it's [done in courtfinder](https://github.com/ministryofjustice/courtfinder-search/blob/master/courtfinder/healthcheck/urls.py#L6)

✨ This has been tested against dev ✨ 