### PR TITLE
RST-715 Disable base layout for api

### DIFF
--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -58,7 +58,12 @@ REST_FRAMEWORK = {
 
 INSTALLED_APPS = INSTALLED_APPS + PROJECT_APPS
 
-TEMPLATES[0]['OPTIONS']['context_processors'].remove('apps.feedback.context_processors.feedback')
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }
+]
 
 # Options for Premailer, which inlines the CSS on the fly in email templates and
 # makes all URLs absolute


### PR DESCRIPTION
Error pages fail to render because settings inherit main site
templates with incomplete settings and dependencies