### PR TITLE
RST-720 Redirect /favicon.ico to static assests

### DIFF
--- a/make_a_plea/urls.py
+++ b/make_a_plea/urls.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, RedirectView
 from apps.plea.views import CourtFinderView
 
 admin.autodiscover()
@@ -40,5 +40,6 @@ urlpatterns = [
         build_tag_key="APP_BUILD_TAG"
     ), name='ping_json'),
     url(r'^500.html$', TemplateView.as_view(template_name="500.html"), name='500_page'),
+    url(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon.ico', permanent=True)),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Eliminate favicon warnings from BrokenLinkEmailsMiddleware