### PR TITLE
Allow different smtp gateways for court emails

### DIFF
--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.db.models import Sum, Count, F
 from django.utils.translation import get_language
 from django.contrib.postgres.fields import HStoreField
+from django.core.exceptions import ValidationError
 
 from .exceptions import *
 from standardisers import (
@@ -680,6 +681,11 @@ class Court(models.Model):
             return True
         else:
             return False
+
+    def clean(self):
+        if not self.court_email.endswith(('@hmcts.gsi.gov.uk', '@justice.gov.uk', '@hmcts.net')):
+            raise ValidationError('Not allowed court email domain')
+
 
 class OUCode(models.Model):
     court = models.ForeignKey(Court)

--- a/apps/plea/models.py
+++ b/apps/plea/models.py
@@ -683,7 +683,7 @@ class Court(models.Model):
             return False
 
     def clean(self):
-        if not self.court_email.endswith(('@hmcts.gsi.gov.uk', '@justice.gov.uk', '@hmcts.net')):
+        if not self.submission_email.endswith(('@hmcts.gsi.gov.uk', '@justice.gov.uk', '@hmcts.net')):
             raise ValidationError('Not allowed court email domain')
 
 

--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -49,10 +49,14 @@ def is_18_or_under(date_of_birth):
     return date_of_birth >= target_date
 
 
+def get_smtp_gateway(email_address):
+    if email_address.endswith('gsi.gov.uk'):
+        return "GSI"
+    return "PUB"
+
+
 @shared_task(bind=True, max_retries=10, default_retry_delay=900)
 def email_send_court(self, case_id, count_id, email_data):
-    smtp_route = "GSI"
-
     email_data["urn"] = format_for_region(email_data["case"]["urn"])
 
     # No error trapping, let these fail hard if the objects can't be found
@@ -76,6 +80,7 @@ def email_send_court(self, case_id, count_id, email_data):
                                          "emails/attachments/plea_email.html",
                                          email_data,
                                          "text/html")
+    smtp_route = get_smtp_gateway(court_obj.court_email)
 
     try:
         with translation.override("en"):

--- a/apps/plea/tasks.py
+++ b/apps/plea/tasks.py
@@ -65,6 +65,7 @@ def email_send_court(self, case_id, count_id, email_data):
     court_obj = get_court(email_data["case"]["urn"], case.ou_code)
 
     plea_email_to = [court_obj.submission_email]
+    smtp_route = get_smtp_gateway(court_obj.submission_email)
 
     email_count = None
     if not court_obj.test_mode:
@@ -80,7 +81,6 @@ def email_send_court(self, case_id, count_id, email_data):
                                          "emails/attachments/plea_email.html",
                                          email_data,
                                          "text/html")
-    smtp_route = get_smtp_gateway(court_obj.court_email)
 
     try:
         with translation.override("en"):

--- a/apps/plea/tests/test_email.py
+++ b/apps/plea/tests/test_email.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from ..tasks import get_smtp_gateway
+
+
+class EmailTests(TestCase):
+    def test_public_smtp_gataway_returned_for_non_gsi_emails(self):
+        self.assertEquals(get_smtp_gateway('test@hmcts.gsi.gov.uk'), 'GSI')
+        self.assertEquals(get_smtp_gateway('test@justice.gov.uk'), 'PUB')
+        self.assertEquals(get_smtp_gateway('test@hmcts.net'), 'PUB')

--- a/apps/plea/tests/test_models.py
+++ b/apps/plea/tests/test_models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import datetime as dt
 
 from django.test import TestCase
+from django.core.exceptions import ValidationError
 
 from ..models import AuditEvent, CourtEmailCount, UsageStats, Court, Case, OUCode, CaseTracker
 
@@ -356,6 +357,13 @@ class TestCourtModel(TestCase):
 
         self.assertEquals(court.id, self.court2.id)
 
+    def test_court_email_domain_validation(self):
+        court = Court.objects.get_court_dx(self.case.urn)
+        court.court_email = 'test@example.com'
+        self.assertRaises(ValidationError, court.clean)
+
+        court.court_email = 'test@justice.gov.uk'
+        court.clean()
 
 class TestAuditEventModel(TestCase):
 

--- a/apps/plea/tests/test_models.py
+++ b/apps/plea/tests/test_models.py
@@ -357,12 +357,12 @@ class TestCourtModel(TestCase):
 
         self.assertEquals(court.id, self.court2.id)
 
-    def test_court_email_domain_validation(self):
+    def test_submission_email_domain_validation(self):
         court = Court.objects.get_court_dx(self.case.urn)
-        court.court_email = 'test@example.com'
+        court.submission_email = 'test@example.com'
         self.assertRaises(ValidationError, court.clean)
 
-        court.court_email = 'test@justice.gov.uk'
+        court.submission_email = 'test@justice.gov.uk'
         court.clean()
 
 class TestAuditEventModel(TestCase):

--- a/make_a_plea/settings/base.py
+++ b/make_a_plea/settings/base.py
@@ -290,12 +290,13 @@ CELERY_RESULT_BACKEND='django-db'
 
 SERVER_EMAIL = os.environ.get("SERVER_EMAIL", "")
 
-# Secure mail
 SMTP_ROUTES = {"GSI": {"HOST": os.environ.get("GSI_EMAIL_HOST", "localhost"),
                        "PORT": os.environ.get("GSI_EMAIL_PORT", 25)},
                "PNN": {"HOST": os.environ.get("PNN_EMAIL_HOST", "localhost"),
-                       "PORT": os.environ.get("PNN_EMAIL_PORT", 25),
-                       "USE_TLS": False}}
+                       "PORT": os.environ.get("PNN_EMAIL_PORT", 25), "USE_TLS": False},
+               "PUB": {"HOST": os.environ.get("EMAIL_HOST", "localhost"),
+                       "PORT": os.environ.get("EMAIL_PORT", 25)}
+               }
 
 # Public email
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")

--- a/make_a_plea/settings/docker.py
+++ b/make_a_plea/settings/docker.py
@@ -22,6 +22,8 @@ SMTP_ROUTES["GSI"]["USERNAME"] = os.environ.get("GSI_EMAIL_USERNAME", "")
 SMTP_ROUTES["GSI"]["PASSWORD"] = os.environ.get("GSI_EMAIL_PASSWORD", "")
 SMTP_ROUTES["PNN"]["USERNAME"] = os.environ.get("PNN_EMAIL_USERNAME", "")
 SMTP_ROUTES["PNN"]["PASSWORD"] = os.environ.get("PNN_EMAIL_PASSWORD", "")
+SMTP_ROUTES["PUB"]["USERNAME"] = os.environ.get("EMAIL_HOST_USER", "")
+SMTP_ROUTES["PUB"]["PASSWORD"] = os.environ.get("EMAIL_HOST_PASSWORD", "")
 
 ALLOWED_HOSTS = [x.strip() for x in os.environ.get("ALLOWED_HOSTS", "localhost:8000").split(',')]
 

--- a/make_a_plea/settings/testing.py
+++ b/make_a_plea/settings/testing.py
@@ -28,7 +28,8 @@ EMAIL_HOST = "127.0.0.1"
 EMAIL_USE_TLS = False
 
 SMTP_ROUTES = {"GSI": {"HOST": "127.0.0.1", "PORT": 1025, "USE_TLS": False},
-               "PNN": {"HOST": "127.0.0.1", "PORT": 1025, "USE_TLS": False}}
+               "PNN": {"HOST": "127.0.0.1", "PORT": 1025, "USE_TLS": False},
+               "PUB": {"HOST": "127.0.0.1", "PORT": 1025, "USE_TLS": False}}
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 


### PR DESCRIPTION
GSI email service is being shut down. Existing email configuration
only allows sending emails to GSI intranet.