### PR TITLE
RST-1690: Remove validation on URN for court finder search

### DIFF
--- a/apps/plea/forms.py
+++ b/apps/plea/forms.py
@@ -1232,7 +1232,6 @@ class CourtFinderForm(forms.Form):
             "class": "form-control"}),
         label=_("Unique reference number (URN)"),
         required=True,
-        validators=[is_urn_valid],
         help_text=_("On page 1, usually at the top."),
         error_messages={
             "required": ERROR_MESSAGES["URN_REQUIRED"],

--- a/apps/plea/views.py
+++ b/apps/plea/views.py
@@ -197,17 +197,6 @@ class CourtFinderView(FormView):
             )
         )
 
-    def form_invalid(self, form):
-        urn_is_invalid = False
-        if "urn" in form.errors and ERROR_MESSAGES["URN_INCORRECT"] in form.errors["urn"]:
-            urn_is_invalid = True
-
-        return self.render_to_response(
-            self.get_context_data(
-                form=form,
-                urn_is_invalid=urn_is_invalid
-            )
-        )
 
 
 @staff_or_404

--- a/features/court_finder.feature
+++ b/features/court_finder.feature
@@ -1,0 +1,24 @@
+Feature: Court finder
+
+  Background:
+    When I visit "/court-finder/"
+
+  Scenario: Only enter 2 numbers correspond to valid court
+    When I submit a valid court code
+    Then I should see "You can contact the court by post or email quoting your URN before the date of your hearing."
+
+  Scenario: Only enter 2 numbers correspond to invalid court
+    When I submit an invalid court code
+    Then I should see "We can't find your court"
+
+  Scenario: Enter invalid URN, but with valid court code
+    When I submit valid court code with invalid URN
+    Then I should see "You can contact the court by post or email quoting your URN before the date of your hearing."
+
+  Scenario: Enter valid URN
+    When I submit a valid URN for court finder
+    Then I should see "You can contact the court by post or email quoting your URN before the date of your hearing."
+
+   Scenario: Enter invalid URN
+    When I submit an invalid URN for court finder
+    Then I should see "We can't find your court"

--- a/features/environment.py
+++ b/features/environment.py
@@ -32,6 +32,12 @@ URNs = {
     'company': '00FF1234564',
     'invalid': '1234',
     'inexistent': '00FF0000000',
+    'invalid_with_valid_region': '00FG1122233'
+}
+
+URNREGIONs = {
+    'valid': '00',
+    'invalid': '99',
 }
 
 # override with -Dkey=value
@@ -66,6 +72,8 @@ def before_all(context):
     context.base_url = config['base_url']
 
     context.URNs = URNs
+
+    context.URNREGIONs = URNREGIONs
 
     benv.before_all(context)
 

--- a/features/steps/urn.py
+++ b/features/steps/urn.py
@@ -12,6 +12,19 @@ def submit_urn_in_welsh(context, urn):
     ''' % context.URNs[urn])
 
 
+def submit_urn_region(context, urn):
+    context.execute_steps(u'''
+        when I fill in "urn" with "%s"
+        and I press "Find my court"
+    ''' % context.URNREGIONs[urn])
+
+
+def submit_urn_court_finder(context, urn):
+    context.execute_steps(u'''
+           when I fill in "urn" with "%s"
+           and I press "Find my court"
+       ''' % context.URNs[urn])
+
 @when(u'I submit a valid URN')
 def step_impl(context):
     submit_urn(context, 'valid')
@@ -139,3 +152,29 @@ def step_impl(context):
         Then the browser's URL should be "plea/company_details/"
         Then I should see "You can only make a plea on behalf of a company if you are a director"
     ''')
+
+
+@when(u'I submit a valid URN for court finder')
+def step_impl(context):
+    submit_urn_court_finder(context, 'valid')
+
+
+@when(u'I submit an invalid URN for court finder')
+def step_impl(context):
+    submit_urn_court_finder(context, 'invalid')
+
+
+@when(u'I submit valid court code with invalid URN')
+def step_impl(context):
+    submit_urn_court_finder(context, 'invalid_with_valid_region')
+
+
+@when(u'I submit a valid court code')
+def step_impl(context):
+    submit_urn_region(context, 'valid')
+
+
+@when(u'I submit an invalid court code')
+def step_impl(context):
+    submit_urn_region(context, 'invalid')
+


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RST-1690

The whole URN entered is not validated, only the first two numbers to find the court. Behave tests added. 